### PR TITLE
헤더 컴포넌트 분리 및 레이아웃 컴포넌트 추가

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { styled } from 'styled-components';
+
+import logo from '../assets/logo.svg';
+import { TextButton } from '../pages/mainPage/MainStyle';
+
+import Dropdown from './Dropdown';
+
+export const HeaderStyle = styled.header`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 70px 53.8px 18px;
+`;
+
+export const Logo = styled.img`
+  width: 200px;
+`;
+
+export const MenuButton = styled(TextButton)`
+  margin-right: 40px;
+`;
+
+export const RightSection = styled.section`
+  display: flex;
+  align-items: center;
+`;
+
+export const ProfileDropdown = styled.div`
+  position: relative;
+`;
+
+export const ProfileImg = styled.img`
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background-color: #000;
+  flex-shrink: 0;
+`;
+
+interface HeaderProps {
+  setProfileModal: React.Dispatch<React.SetStateAction<boolean>>;
+  profileRef: React.RefObject<HTMLImageElement>;
+  profileModal: boolean;
+}
+
+const Header: React.FC<HeaderProps> = ({
+  setProfileModal,
+  profileRef,
+  profileModal,
+}) => {
+  const handleProfileClick = () => {
+    setProfileModal((prev) => !prev);
+  };
+  const DropdwonList = ['마이페이지', '로그아웃'];
+  return (
+    <HeaderStyle>
+      <Logo src={logo} alt="Logo" />
+      <RightSection>
+        <MenuButton>이벤트</MenuButton>
+        <MenuButton>리뷰</MenuButton>
+        <ProfileDropdown>
+          <ProfileImg
+            src="https://i.pinimg.com/564x/f6/bb/3d/f6bb3d066a4b0066689e47cdec0cf3c0.jpg"
+            alt="Profile"
+            onClick={handleProfileClick}
+            ref={profileRef}
+          />
+          {profileModal ? (
+            <Dropdown lists={DropdwonList} setClicked={setProfileModal} />
+          ) : null}
+        </ProfileDropdown>
+      </RightSection>
+    </HeaderStyle>
+  );
+};
+
+export default Header;

--- a/src/layout/GeneralLayout.tsx
+++ b/src/layout/GeneralLayout.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useState } from 'react';
+import { styled } from 'styled-components';
+
+import Billboard from '../components/Billboard';
+import Header from '../components/Header';
+
+interface GeneralLayoutProps {
+  children: React.ReactNode;
+}
+
+const PageWrapper = styled.section`
+  display: flex;
+  flex-direction: column;
+`;
+
+const GeneralLayout: React.FC<GeneralLayoutProps> = ({ children }) => {
+  const [profileModal, setProfileModal] = useState(false);
+  const profileRef = useRef<HTMLImageElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        profileRef.current &&
+        !profileRef.current.contains(event.target as Node)
+      ) {
+        setProfileModal(false);
+      }
+    };
+
+    document.addEventListener('click', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <PageWrapper>
+      <Billboard />
+      <Header
+        setProfileModal={setProfileModal}
+        profileRef={profileRef}
+        profileModal={profileModal}
+      />
+      {children}
+    </PageWrapper>
+  );
+};
+
+export default GeneralLayout;

--- a/src/pages/mainPage/Main.tsx
+++ b/src/pages/mainPage/Main.tsx
@@ -1,17 +1,8 @@
 import { useState, useEffect, useRef } from 'react';
 
-import logo from '../../assets/logo.svg';
-import Billboard from '../../components/Billboard';
-import Dropdown from '../../components/Dropdown';
 import SortDropdown from '../../components/SortButton';
 
 import {
-  Header,
-  Logo,
-  MenuButton,
-  RightSection,
-  ProfileDropdown,
-  ProfileImg,
   MainSection,
   MapSection,
   ViewReviews,
@@ -21,20 +12,11 @@ import {
 } from './MainStyle';
 
 const Main = () => {
-  const [profileModal, setProfileModal] = useState(false);
-  const DropdwonList: string[] = ['마이페이지', '로그아웃'];
-  const profileRef = useRef<HTMLImageElement>(null);
   const sortButtonRef = useRef<HTMLButtonElement>(null);
   const [SortModal, setSortModal] = useState(false);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (
-        profileRef.current &&
-        !profileRef.current.contains(event.target as Node)
-      ) {
-        setProfileModal(false);
-      }
       if (
         sortButtonRef.current &&
         !sortButtonRef.current.contains(event.target as Node)
@@ -50,31 +32,8 @@ const Main = () => {
     };
   }, []);
 
-  const handleProfileClick = () => {
-    setProfileModal((prev) => !prev);
-  };
-
   return (
     <>
-      <Billboard />
-      <Header>
-        <Logo src={logo} alt="Logo" />
-        <RightSection>
-          <MenuButton>이벤트</MenuButton>
-          <MenuButton>리뷰</MenuButton>
-          <ProfileDropdown>
-            <ProfileImg
-              src="https://i.pinimg.com/564x/f6/bb/3d/f6bb3d066a4b0066689e47cdec0cf3c0.jpg"
-              alt="Profile"
-              onClick={handleProfileClick}
-              ref={profileRef}
-            />
-            {profileModal ? (
-              <Dropdown lists={DropdwonList} setClicked={setProfileModal} />
-            ) : null}
-          </ProfileDropdown>
-        </RightSection>
-      </Header>
       <MainSection>
         <SortDropdown
           sortButtonRef={sortButtonRef}


### PR DESCRIPTION
## Describe your changes
거의 모든 페이지에서 동일한 헤더가 반복되어서 만들었습니다.

- 거의 모든 페이지에서 반복되는 헤더 부분 컴포넌트 분리
- 레이아웃컴포넌트 만들어 반복되는 헤더 적용

**사용 방법**

`GeneralLayout` 컴포넌트의 `children` 속성에 원하는 페이지 컴포넌트를 전달하면 됩니다.
레이아웃에는 전광판과 헤더가 포함되어 있으므로, 페이지 컴포넌트는 전광판과 헤더를 고려하지 않아도 됩니다.

예시)
```tsx
      <GeneralLayout>
        <Main />
      </GeneralLayout>
```
