### PR TITLE
이벤트 상세페이지 작업

### DIFF
--- a/src/components/ReviewItem.tsx
+++ b/src/components/ReviewItem.tsx
@@ -1,0 +1,90 @@
+import { styled } from 'styled-components';
+
+import FixedRating from './FixedRating';
+
+const ReviewWrapper = styled.li`
+  width: 100%;
+  max-width: 1042px;
+  height: 204px;
+  display: flex;
+  margin-bottom: 20px;
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+const ProfileImg = styled.img`
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  margin-right: 20px;
+`;
+
+const MiddleSection = styled.section``;
+
+const ReviewInfoText = styled.span`
+  font-size: 1.4rem;
+  &:nth-child(2) {
+    margin-right: 58px;
+  }
+`;
+
+const ReviewContents = styled.p`
+  width: 100%;
+  max-width: 721px;
+  font-size: 1.4rem;
+  overflow: hidden;
+  word-break: break-all;
+  text-overflow: ellipsis;
+  margin-top: 5px;
+  margin-right: 49px;
+  display: -webkit-box;
+  -webkit-line-clamp: 8;
+  -webkit-box-orient: vertical;
+`;
+
+const ReviewPhoto = styled.img`
+  width: 200px;
+  height: 200px;
+`;
+
+const ReviewItem = () => {
+  return (
+    <ReviewWrapper>
+      <ProfileImg
+        alt="사용자 프로필"
+        src="https://i.pinimg.com/736x/07/67/a9/0767a97903445549adcb066bb9ee74e3.jpg"
+      />
+      <MiddleSection>
+        <FixedRating score={3.5} />
+        <ReviewInfoText>username</ReviewInfoText>
+        <ReviewInfoText>2023.05.25</ReviewInfoText>
+        <ReviewContents>
+          Lorem Ipsum is simply dummy text of the printing and typesetting
+          industry. Lorem Ipsum has been the industrys standard dummy text ever
+          since the 1500s, when an unknown printer took a galley of type and
+          scrambled it to make a type specimen book. It has survived not only
+          five centuries, but also the leap into electronic typesetting,
+          remaining essentially unchanged. It was popularised in the 1960s with
+          the release of Letraset sheets containing Lorem Ipsum passages, and
+          more recently with desktop publishing software like Aldus PageMaker
+          including versions of Lorem Ipsum Lorem Ipsum is simply dummy text of
+          the printing and typesetting industry. Lorem Ipsum has been the
+          industrys standard dummy text ever since the 1500s, when an unknown
+          printer took a galley of type and scrambled it to make a type specimen
+          book. It has survived not only five centuries, but also the leap into
+          electronic typesetting, remaining essentially unchanged. It was
+          popularised in the 1960s with the release of Letraset sheets
+          containing Lorem Ipsum passages, and more recently with desktop
+          publishing software like Aldus PageMaker including versions of Lorem
+          Ipsum
+        </ReviewContents>
+      </MiddleSection>
+      <ReviewPhoto
+        src="https://images.unsplash.com/photo-1481833761820-0509d3217039?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1170&q=80"
+        alt="카페 리뷰 사진"
+      />
+    </ReviewWrapper>
+  );
+};
+
+export default ReviewItem;

--- a/src/pages/DetailInfoPage/DetailInfo.tsx
+++ b/src/pages/DetailInfoPage/DetailInfo.tsx
@@ -25,6 +25,8 @@ import {
   TabInfoImg,
   TabMapImg,
 } from './DetailInfoStyle';
+import MapSection from './MapSection';
+import ReviewSection from './ReviewSection';
 
 const DetailInfo = () => {
   type CurrentType = 'info' | 'map' | 'review';
@@ -124,6 +126,13 @@ const DetailInfo = () => {
           Review
         </TabButton>
       </TabSection>
+      {currentTab === 'info' ? (
+        <InfoSection />
+      ) : currentTab === 'map' ? (
+        <MapSection />
+      ) : currentTab === 'review' ? (
+        <ReviewSection />
+      ) : null}
     </PageWrapper>
   );
 };

--- a/src/pages/DetailInfoPage/DetailInfo.tsx
+++ b/src/pages/DetailInfoPage/DetailInfo.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+
+import coffecupActive from '../../assets/coffee-cup-active.svg';
+import coffecup from '../../assets/coffee-cup-disabled.svg';
+import mapActive from '../../assets/map-active.svg';
+import map from '../../assets/map-disabled.svg';
+import Button from '../../components/Button';
+import FixedRating from '../../components/FixedRating';
+
+import {
+  ImgSection,
+  EventImg,
+  PageWrapper,
+  TopSection,
+  InfoSection,
+  ImgNumMarkWrapper,
+  ImgNumMarkCirclePurple,
+  ImgNumMarkCircle,
+  HeartButtonWrapper,
+  HeartButton,
+  LikeNum,
+  BookmarkButton,
+  TabSection,
+  TabButton,
+  TabInfoImg,
+  TabMapImg,
+} from './DetailInfoStyle';
+
+const DetailInfo = () => {
+  type CurrentType = 'info' | 'map' | 'review';
+  // TODO: 예시 이미지 삭제하기
+  const testImg = [
+    'https://images.unsplash.com/photo-1567880905822-56f8e06fe630?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=735&q=80',
+    'https://images.unsplash.com/photo-1534040385115-33dcb3acba5b?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80',
+    'https://images.unsplash.com/photo-1508424757105-b6d5ad9329d0?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1335&q=80',
+  ];
+
+  const [currentTab, setCurrentTab] = useState<CurrentType>('info');
+
+  const handleTabClick = (tab: CurrentType) => {
+    setCurrentTab(tab);
+  };
+
+  const [currentImg, setCurrentImg] = useState(0);
+  const [isLike, setIsLike] = useState(false);
+  const [isBookmark, setIsBookmark] = useState(false);
+
+  return (
+    <PageWrapper>
+      <TopSection>
+        {/* TODO: 이미지 슬라이드 기능 추가 */}
+        <ImgSection>
+          <EventImg url={testImg[currentImg]} />
+          <ImgNumMarkWrapper>
+            {testImg.map((_, i) =>
+              i === currentImg ? (
+                <ImgNumMarkCirclePurple
+                  key={i}
+                  onClick={() => setCurrentImg(i)}
+                />
+              ) : (
+                <ImgNumMarkCircle key={i} onClick={() => setCurrentImg(i)} />
+              )
+            )}
+          </ImgNumMarkWrapper>
+          <HeartButtonWrapper onClick={() => setIsLike((prev) => !prev)}>
+            <HeartButton checked={isLike} />
+            {/* TODO: 좋아요값 서버에서 가져오기 */}
+            <LikeNum>123</LikeNum>
+          </HeartButtonWrapper>
+          <BookmarkButton
+            checked={isBookmark}
+            onClick={() => {
+              setIsBookmark((prev) => !prev);
+            }}
+          />
+        </ImgSection>
+
+        <InfoSection>
+          {/* TODO: 세희님 텍스트 박스 컴포넌트 div 완성되면 바꾸기 */}
+          <div>상호명</div>
+          <div>이벤트 기간</div>
+          <div>주소</div>
+          <Button color="primary" size="mid">
+            복사
+          </Button>
+          <div>영업 시간</div>
+          <div>해시태그</div>
+          <Button color="primary" size="mid">
+            복사
+          </Button>
+          {/* TODO: 나중에 평균 별점값 받아오기 */}
+          <FixedRating score={4.5} />
+        </InfoSection>
+      </TopSection>
+      <TabSection>
+        <TabButton
+          onClick={() => {
+            handleTabClick('info');
+          }}
+          currentTab={currentTab}
+          tabType="info"
+        >
+          <TabInfoImg src={currentTab === 'info' ? coffecupActive : coffecup} />
+          Info
+        </TabButton>
+        <TabButton
+          onClick={() => {
+            handleTabClick('map');
+          }}
+          currentTab={currentTab}
+          tabType="map"
+        >
+          <TabMapImg src={currentTab === 'map' ? mapActive : map} />
+          Map
+        </TabButton>
+        <TabButton
+          onClick={() => {
+            handleTabClick('review');
+          }}
+          currentTab={currentTab}
+          tabType="review"
+        >
+          Review
+        </TabButton>
+      </TabSection>
+    </PageWrapper>
+  );
+};
+
+export default DetailInfo;

--- a/src/pages/DetailInfoPage/DetailInfoStyle.tsx
+++ b/src/pages/DetailInfoPage/DetailInfoStyle.tsx
@@ -143,6 +143,8 @@ export const TabButton = styled.button<{
   justify-content: flex-end;
   color: ${(props) =>
     props.currentTab === props.tabType ? 'var(--purple)' : 'var(--disabled)'};
+  border-bottom: ${(props) =>
+    props.currentTab === props.tabType ? `5px solid var(--purple)` : ''};
   cursor: pointer;
 `;
 

--- a/src/pages/DetailInfoPage/DetailInfoStyle.tsx
+++ b/src/pages/DetailInfoPage/DetailInfoStyle.tsx
@@ -1,0 +1,161 @@
+import styled from 'styled-components';
+
+import bookmark from '../../assets/bookmark-empty.svg';
+import bookmarkActive from '../../assets/bookmark-filled.svg';
+import heart from '../../assets/empty-heart.svg';
+import heartActive from '../../assets/filled-heart.svg';
+
+export const PageWrapper = styled.main``;
+
+export const TopSection = styled.section`
+  display: flex;
+  justify-content: center;
+  gap: 55px;
+`;
+
+export const ImgSection = styled.section`
+  position: relative;
+`;
+
+export const EventImg = styled.section<{ url: string }>`
+  width: 460px;
+  height: 460px;
+  background-image: url(${(props) => props.url});
+`;
+
+export const ImgNumMarkWrapper = styled.section`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin-top: 30px;
+  & > div {
+    margin-right: 26px;
+  }
+  & > div:last-child {
+    margin-right: 0;
+  }
+`;
+
+export const ImgNumMarkCircle = styled.div`
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: var(--disabled);
+  cursor: pointer;
+`;
+
+export const ImgNumMarkCirclePurple = styled(ImgNumMarkCircle)`
+  background-color: var(--purple);
+`;
+
+export const HeartButtonWrapper = styled.div`
+  width: fit-content;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: absolute;
+  right: 78px;
+  bottom: -17px;
+`;
+
+export const LikeNum = styled.span`
+  font-size: 1.6rem;
+`;
+
+export const HeartButton = styled.button<{ checked: boolean }>`
+  width: 30px;
+  height: 27px;
+  background-image: url(${(props) => (props.checked ? heartActive : heart)});
+  background-repeat: no-repeat;
+  background-size: contain;
+`;
+
+export const BookmarkButton = styled(HeartButton)`
+  width: 35px;
+  height: 45px;
+  position: absolute;
+  right: 16px;
+  bottom: -17px;
+  ${(props) =>
+    props.checked
+      ? `background-image: url(${bookmarkActive})`
+      : `background-image: url(${bookmark})`}
+`;
+
+export const InfoSection = styled.section`
+  width: 100%;
+  max-width: 502px;
+  display: grid;
+  grid-template-columns: 1fr 119px;
+  grid-template-rows: repeat(6, 50px);
+  position: relative;
+  gap: 15px 23px;
+  /* TODO: 텍스트 박스 컴포넌트 추가하면 없애기 */
+  & > div {
+    width: 100%;
+    padding: 13px 0 18px;
+    text-align: center;
+    border-radius: 5px;
+    border: 1px solid var(--blue-purple);
+  }
+  & > div:first-child {
+    grid-column: 1 / 3;
+  }
+  & > div:nth-child(2) {
+    grid-column: 1 / 3;
+  }
+  & > div:nth-child(5) {
+    grid-column: 1 / 3;
+  }
+  & > div:last-child {
+    position: absolute;
+    bottom: 23.5px;
+    justify-content: center;
+    border: none;
+  }
+`;
+
+export const DetailSection = styled.section``;
+
+export const TabSection = styled.section`
+  display: flex;
+  justify-content: center;
+  margin-top: 60px;
+  padding-bottom: 31px;
+  border-bottom: 3px solid var(--purple);
+  & > button {
+    margin-right: 62px;
+  }
+  & > button:last-child {
+    margin-right: 0;
+  }
+`;
+
+export const TabButton = styled.button<{
+  currentTab?: string;
+  tabType: string;
+}>`
+  width: 50px;
+  height: 56px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  color: ${(props) =>
+    props.currentTab === props.tabType ? 'var(--purple)' : 'var(--disabled)'};
+  cursor: pointer;
+`;
+
+export const TabInfoImg = styled.img`
+  width: 40px;
+  height: 40px;
+  margin-bottom: 4px;
+`;
+
+export const TabMapImg = styled.img`
+  width: 30px;
+  height: 30px;
+  margin-bottom: 7px;
+`;
+
+export const DetailContents = styled.section``;

--- a/src/pages/DetailInfoPage/InfoSection.tsx
+++ b/src/pages/DetailInfoPage/InfoSection.tsx
@@ -1,0 +1,13 @@
+import { styled } from 'styled-components';
+
+// TODO: 트위터 임베드 해오기
+const TwitterEmbedSection = styled.section`
+  width: 100%;
+  height: fit-content;
+`;
+
+const InfoSection = () => {
+  return <TwitterEmbedSection>트위터 임베드 공간</TwitterEmbedSection>;
+};
+
+export default InfoSection;

--- a/src/pages/DetailInfoPage/MapSection.tsx
+++ b/src/pages/DetailInfoPage/MapSection.tsx
@@ -6,12 +6,12 @@ const PageWrapper = styled.section`
   display: flex;
   flex-direction: column;
   align-items: center;
-  background-color: #000;
 `;
 
 const MapSpace = styled.section`
   width: 100%;
   height: 554px;
+  background-color: #000;
 `;
 
 const MapSection = () => {

--- a/src/pages/DetailInfoPage/MapSection.tsx
+++ b/src/pages/DetailInfoPage/MapSection.tsx
@@ -1,0 +1,27 @@
+import { styled } from 'styled-components';
+
+const PageWrapper = styled.section`
+  width: 100%;
+  padding: 177px 146px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: #000;
+`;
+
+const MapSpace = styled.section`
+  width: 100%;
+  height: 554px;
+`;
+
+const MapSection = () => {
+  return (
+    <PageWrapper>
+      <MapSpace />
+      {/* TODO: TextBox 컴포넌트 추가되면 교체 */}
+      <div>주소</div>
+    </PageWrapper>
+  );
+};
+
+export default MapSection;

--- a/src/pages/DetailInfoPage/ReviewSection.tsx
+++ b/src/pages/DetailInfoPage/ReviewSection.tsx
@@ -1,0 +1,28 @@
+import { styled } from 'styled-components';
+
+import ReviewItem from '../../components/ReviewItem';
+
+const PageWrapper = styled.ul`
+  padding-top: 143px;
+  padding-bottom: 50px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const ReviewSection = () => {
+  return (
+    <PageWrapper>
+      <ReviewItem />
+      <ReviewItem />
+      <ReviewItem />
+      <ReviewItem />
+      <ReviewItem />
+      <ReviewItem />
+      <ReviewItem />
+      <ReviewItem />
+    </PageWrapper>
+  );
+};
+
+export default ReviewSection;


### PR DESCRIPTION
## Describe your changes

이벤트 상세페이지 작업
- 하트. 북마크 버튼 클릭 시 색 채움
- 탭 버튼 클릭시 색상 변경 및 탭 이동
- 리뷰 아이템 컴포넌트 추가
- 이미지 밑의 점 클릭 시 해당 인덱스 이미지로 이동 (추후에 슬라이드 기능 추가하고 삭제할 예정입니다)

## Screenshot
- 전체화면
![전체화면](https://github.com/duck-map-project/duck-map-fe/assets/100986977/6c2f57a3-f8ff-4715-b985-def4cd27a6b3)

- 리뷰아이템
![리뷰아이템](https://github.com/duck-map-project/duck-map-fe/assets/100986977/32f3d0b4-04db-4dbb-8d94-615e0e096fe1)

- 좋아요 / 북마크
![좋아요북마크버튼들](https://github.com/duck-map-project/duck-map-fe/assets/100986977/a7bd3180-8546-4ad5-83b0-200bd577935a)

- 이미지 이동 (삭제 예정)
![이미지 이동](https://github.com/duck-map-project/duck-map-fe/assets/100986977/33b1b58f-a8f8-431a-861e-8c6ca990841a)

- 탭 이동
![탭이동](https://github.com/duck-map-project/duck-map-fe/assets/100986977/25ddc35f-a466-4f37-8fe4-f609c37f094c)

textbox 등 아직 추가 되지 않은 버튼은 대충 스타일링 해서 작성하거나 div로 처리 했습니다. map, info 탭은 추후 보완될 예정입니다. (카카오지도, 트위터 임베드)