### PR TITLE
Fix: 스타일드 컴포넌트 clicked 변수 에러 핸들링

### DIFF
--- a/src/components/SortButton.tsx
+++ b/src/components/SortButton.tsx
@@ -11,14 +11,14 @@ const Wrapper = styled.div`
   margin-right: 10px;
 `;
 
-const Select = styled.button<{ clicked: boolean }>`
+const Select = styled.button<{ $clicked: boolean }>`
   width: 180px;
   height: 50px;
   font-size: 1.6rem;
   border: 1px solid var(--purple);
   border-radius: 5px;
-  background-image: ${({ clicked }) =>
-    clicked ? `url(${arrowUp})` : `url(${arrowDown})`};
+  background-image: ${({ $clicked }) =>
+    $clicked ? `url(${arrowUp})` : `url(${arrowDown})`};
   background-repeat: no-repeat;
   background-position: right 30px center;
 `;
@@ -46,7 +46,7 @@ const SortDropdown: React.FC<SortDropdownProps> = ({
   };
   return (
     <Wrapper>
-      <Select clicked={clicked} onClick={handleClick} ref={sortButtonRef}>
+      <Select $clicked={clicked} onClick={handleClick} ref={sortButtonRef}>
         {SelectedText}
       </Select>
       {clicked ? (


### PR DESCRIPTION
## Describe your changes

스타일 컴포넌트에서 모든 props를 DOM으로 보내면서 생기는 오류.

변수 앞에 `$` prefix 를 사용하면 전달하지 않는다고 합니다.



참고
https://github.com/styled-components/styled-components/pull/2093
