### PR TITLE
리프레쉬 토큰 구현

### DIFF
--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -1,3 +1,5 @@
+import { AxiosError, AxiosResponse } from 'axios';
+
 import { AuthRequest, SignupRequest } from '../types/auth';
 
 import client from './client';
@@ -27,9 +29,8 @@ export const signin = async ({ email, password }: AuthRequest) => {
 
   try {
     const res = await client.post('/auth/login', requestData);
-    const accessToken = res.headers.authorization;
     if (res.request.status === 200) {
-      client.defaults.headers.common['Authorization'] = accessToken;
+      onSigninSuccess(res);
       return 'success';
     }
   } catch (error) {
@@ -46,4 +47,25 @@ export const signout = async () => {
   } catch (error) {
     throw error;
   }
+};
+
+export const getNewToken = async () => {
+  try {
+    const res = await client.post('/auth/reissue', {});
+    if (res.status === 200) {
+      onSigninSuccess(res);
+    }
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      if (error.status === 401) {
+      }
+    }
+  }
+};
+
+export const onSigninSuccess = (res: AxiosResponse) => {
+  const JWT_EXPIRY_TIME = 30 * 60 * 1000;
+  const accessToken = res.headers.authorization;
+  client.defaults.headers.common['Authorization'] = accessToken;
+  setTimeout(getNewToken, JWT_EXPIRY_TIME - 60000);
 };

--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -69,3 +69,15 @@ export const onSigninSuccess = (res: AxiosResponse) => {
   client.defaults.headers.common['Authorization'] = accessToken;
   setTimeout(getNewToken, JWT_EXPIRY_TIME - 60000);
 };
+
+export const fetchUser = async () => {
+  try {
+    const res = await client.get('/members/me');
+
+    if (res.status === 200) {
+      return res.data;
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from 'axios';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
-import { signin, signout, signup } from '../api/authApi';
+import { getNewToken, signin, signout, signup } from '../api/authApi';
 import client from '../api/client';
 import { SignupRequest, AuthRequest } from '../types/auth';
 
@@ -41,7 +41,6 @@ export const useAuth = (): Auth => {
   const { routeTo } = useRouter();
 
   useEffect(() => {
-    // isLogin 값 바뀔 때
     localStorage.setItem('isLogin', String(isLogin));
   }, [isLogin]);
 
@@ -69,11 +68,14 @@ export const useAuth = (): Auth => {
   };
 
   useEffect(() => {
-    if (isLogin) {
-      FetchUser();
-    } else {
-      localStorage.removeItem('user');
-    }
+    (async () => {
+      await getNewToken();
+      if (isLogin) {
+        FetchUser();
+      } else {
+        localStorage.removeItem('user');
+      }
+    })();
   }, [isLogin]);
 
   const signIn = async (data: AuthRequest) => {

--- a/src/hooks/useLocalStarage.ts
+++ b/src/hooks/useLocalStarage.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+
+const useLocalStorage = <T>(key: string, defaultValue: T) => {
+  const [value, setValue] = useState(() => {
+    let currentValue;
+
+    try {
+      currentValue = JSON.parse(
+        localStorage.getItem(key) || JSON.stringify(defaultValue)
+      );
+    } catch (error) {
+      currentValue = defaultValue;
+    }
+
+    return currentValue;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(value));
+  }, [value, key]);
+
+  return [value, setValue];
+};
+
+export default useLocalStorage;


### PR DESCRIPTION
## Describe your changes

- 페이지 리로드 시 /reissue api로 access 토큰 재발급
- access token 만료되기 1분전에 재발급
- useLocalStorage 추가 및 적용
- useAuth에 있던 fetchUser authApi로 분리
