### PR TITLE
메인 페이지에 표시할 오늘 진행 중인 이벤트의 해시태그를 가져오는 API 호출

### DIFF
--- a/src/api/evnet.ts
+++ b/src/api/evnet.ts
@@ -1,6 +1,6 @@
 import client from './client';
 
-export const todayHashtag = async () => {
+export const todayHashtags = async () => {
   try {
     const res = await client.get('/events/hashtags/today');
     if (res.status === 200) {

--- a/src/api/evnet.ts
+++ b/src/api/evnet.ts
@@ -1,0 +1,12 @@
+import client from './client';
+
+export const todayHashtag = async () => {
+  try {
+    const res = await client.get('/events/hashtags/today');
+    if (res.status === 200) {
+      return res.data;
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/components/Billboard.tsx
+++ b/src/components/Billboard.tsx
@@ -1,4 +1,7 @@
+import { useEffect, useState } from 'react';
 import styled, { keyframes } from 'styled-components';
+
+import { todayHashtags } from '../api/evnet';
 
 const SlideLeftAnimation = keyframes`
   from {
@@ -41,33 +44,36 @@ const ListItem = styled.li`
   }
 `;
 
+interface HashTag {
+  eventId: number;
+  hashtag: string;
+}
+
 const Billboard = () => {
+  const [hashtags, setHashtags] = useState<HashTag[]>([]);
+
+  const fetchTodayHashtag = async () => {
+    try {
+      const res = await todayHashtags();
+      setHashtags(res);
+      console.log(res);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    fetchTodayHashtag();
+  }, []);
+
+  const listItems = hashtags.map((hashtag, index) => (
+    <ListItem key={index}>{hashtag.hashtag}</ListItem>
+  ));
   return (
     <Container>
       <Wrapper>
-        <HashtagList>
-          {/* FIXME: 나중에 동적으로 텍스트 받아오기. 현재는 테스트용 텍스트 */}
-          <ListItem>해시태그</ListItem>
-          <ListItem>해시태그</ListItem>
-          <ListItem>해시태그</ListItem>
-          <ListItem>해시태그 Korea</ListItem>
-          <ListItem>해시태그</ListItem>
-          <ListItem>해시태그</ListItem>
-          <ListItem>해시태그</ListItem>
-          <ListItem>해시태그 States</ListItem>
-          <ListItem>해시태그</ListItem>
-        </HashtagList>
-        <HashtagList>
-          <ListItem>해시태그</ListItem>
-          <ListItem>해시태그</ListItem>
-          <ListItem>해시태그</ListItem>
-          <ListItem>해시태그 Korea</ListItem>
-          <ListItem>해시태그</ListItem>
-          <ListItem>해시태그</ListItem>
-          <ListItem>해시태그</ListItem>
-          <ListItem>해시태그 States</ListItem>
-          <ListItem>해시태그</ListItem>
-        </HashtagList>
+        <HashtagList>{listItems}</HashtagList>
+        <HashtagList>{listItems}</HashtagList>
       </Wrapper>
     </Container>
   );


### PR DESCRIPTION
## Describe your changes

메인페이지의 Billboard 컴포넌트에 오늘 진행중인 이벤트의 해시태그를 api 호출을 통해 불러오고 해시태그를 렌더링

mock api 사용
