### PR TITLE
이미지 조회/저장 api, 그룹/아티스트 등록 모달 및 기능 

### DIFF
--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -3,14 +3,18 @@ import { styled } from 'styled-components';
 import { useAuthContext } from '../contexts/AuthContext';
 import { useRouter } from '../hooks/useRouter';
 
+import { sortOptionsType } from './modals/AddArtistModal';
+
 const Wrapper = styled.ul`
   position: absolute;
   top: 120%;
   width: 157px;
+  max-height: 180px;
   border-radius: 20px;
   border: 2px solid #1e232c;
   background-color: var(--yellow);
   z-index: 999;
+  overflow-y: scroll;
 `;
 
 const Item = styled.li`
@@ -50,20 +54,22 @@ const Item = styled.li`
 `;
 
 interface DropdownProps {
-  lists: string[];
-  setSelectedText?: React.Dispatch<React.SetStateAction<string>>;
+  lists: sortOptionsType[];
+  setSelectedText?: React.Dispatch<React.SetStateAction<string | null>>;
   setClicked: React.Dispatch<React.SetStateAction<boolean>>;
+  setId: React.Dispatch<React.SetStateAction<number | null>>;
 }
 
 const Dropdown: React.FC<DropdownProps> = ({
   lists,
   setSelectedText,
   setClicked,
+  setId,
 }) => {
   const auth = useAuthContext();
   const { routeTo } = useRouter();
 
-  const handleListClick = (list: string) => {
+  const handleListClick = (list: string, id: number) => {
     switch (list) {
       case '로그아웃':
         auth?.signOut();
@@ -79,19 +85,22 @@ const Dropdown: React.FC<DropdownProps> = ({
       default:
         setSelectedText && setSelectedText(list);
         setClicked(false);
+        setId(id);
         break;
     }
   };
+
   return (
     <Wrapper>
       {lists.map((list, i) => (
         <Item
           key={i}
+          value={list.id}
           onClick={() => {
-            handleListClick(list);
+            handleListClick(list.sort, list.id);
           }}
         >
-          {list}
+          {list.sort}
         </Item>
       ))}
     </Wrapper>

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -4,66 +4,47 @@ import { useAuthContext } from '../contexts/AuthContext';
 import { useRouter } from '../hooks/useRouter';
 
 const Wrapper = styled.ul`
+  position: absolute;
+  top: 120%;
   width: 157px;
-  padding: 16px 0;
   border-radius: 20px;
   border: 2px solid #1e232c;
-  position: absolute;
-  top: 47px;
-  left: 50%;
-  transform: translateX(-50%);
   background-color: var(--yellow);
   z-index: 999;
-  &::after {
-    content: '';
-    width: 129px;
-    height: 1px;
-    background-color: #000;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%);
-  }
 `;
 
 const Item = styled.li`
+  position: relative;
   width: 100%;
   text-align: center;
   font-size: 1.8rem;
   font-weight: 700;
   line-height: 1.247777777777778;
-  padding-bottom: 10px;
-  position: relative;
+  padding: 10px;
   cursor: pointer;
-  &:last-child {
-    padding-top: 16px;
-    padding-bottom: 0;
-    &:hover {
-      &::after {
-        content: '';
-        width: 44px;
-        height: 7px;
-        background-color: #d1cf78;
-        position: absolute;
-        top: 32px;
-        left: 65px;
-        z-index: -10;
-      }
-    }
-  }
   &:hover {
     &::after {
+      display: block;
       content: '';
       width: 44px;
       height: 7px;
       background-color: #d1cf78;
+      opacity: 0.5;
       position: absolute;
-      top: 16px;
+      top: 24px;
       left: 65px;
-      z-index: -10;
-      &:last-child {
-        top: 26px;
-      }
+    }
+  }
+  &:not(:last-of-type) {
+    &::before {
+      content: '';
+      width: 129px;
+      height: 1px;
+      background-color: #000;
+      position: absolute;
+      bottom: 0;
+      left: 50%;
+      transform: translate(-50%);
     }
   }
 `;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,6 +12,7 @@ import { useAuthContext } from '../contexts/AuthContext';
 import { useRouter } from '../hooks/useRouter';
 import { TextButton } from '../pages/mainPage/MainStyle';
 import { toggleGroup } from '../redux/manageModalSlice';
+import { toggleArtist } from '../redux/manageModalSlice';
 import px2vw from '../utils/px2vw';
 
 export const HeaderStyle = styled.header`
@@ -98,7 +99,7 @@ const Header: React.FC = ({}) => {
     dispatch(toggleGroup());
   };
   const handleArtistClick = () => {
-    console.log('아티스트 등록!');
+    dispatch(toggleArtist());
   };
 
   const handleCategoryClick = () => {

--- a/src/components/SortButton.tsx
+++ b/src/components/SortButton.tsx
@@ -5,6 +5,7 @@ import arrow from '../assets/sort-arrow.svg';
 import sortIcon from '../assets/sort-book.svg';
 
 import Dropdown from './Dropdown';
+import { sortOptionsType } from './modals/AddArtistModal';
 
 const Select = styled.button<{ $clicked: boolean }>`
   width: 157px;
@@ -39,9 +40,10 @@ export interface SortDropdownProps {
   clicked: boolean;
   setClicked: React.Dispatch<React.SetStateAction<boolean>>;
   sortButtonRef: React.RefObject<HTMLButtonElement>;
-  sortOption: string[];
-  selectedText: string;
-  setSelectedText: React.Dispatch<React.SetStateAction<string>>;
+  sortOptions: sortOptionsType[];
+  selectedText: string | null;
+  setSelectedText: React.Dispatch<React.SetStateAction<string | null>>;
+  setId: React.Dispatch<React.SetStateAction<number | null>>;
 }
 
 const SortDropdown: React.FC<SortDropdownProps> = ({
@@ -49,9 +51,10 @@ const SortDropdown: React.FC<SortDropdownProps> = ({
   clicked,
   setClicked,
   sortButtonRef,
-  sortOption,
+  sortOptions,
   selectedText,
   setSelectedText,
+  setId,
 }) => {
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
@@ -61,6 +64,7 @@ const SortDropdown: React.FC<SortDropdownProps> = ({
       setClicked(true);
     }
   };
+
   return (
     <div className={className}>
       <Select $clicked={clicked} onClick={handleClick} ref={sortButtonRef}>
@@ -68,9 +72,10 @@ const SortDropdown: React.FC<SortDropdownProps> = ({
       </Select>
       {clicked ? (
         <Dropdown
-          lists={sortOption}
+          lists={sortOptions}
           setSelectedText={setSelectedText}
           setClicked={setClicked}
+          setId={setId}
         />
       ) : null}
     </div>

--- a/src/components/SortButton.tsx
+++ b/src/components/SortButton.tsx
@@ -1,17 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { styled } from 'styled-components';
 
 import arrow from '../assets/sort-arrow.svg';
 import sortIcon from '../assets/sort-book.svg';
 
 import Dropdown from './Dropdown';
-
-const Wrapper = styled.div`
-  position: absolute;
-  margin-right: 10px;
-  top: 42px;
-  right: 39px;
-`;
 
 const Select = styled.button<{ $clicked: boolean }>`
   width: 157px;
@@ -41,21 +34,27 @@ const Select = styled.button<{ $clicked: boolean }>`
   }
 `;
 
-interface SortDropdownProps {
+export interface SortDropdownProps {
+  className: string;
   clicked: boolean;
   setClicked: React.Dispatch<React.SetStateAction<boolean>>;
   sortButtonRef: React.RefObject<HTMLButtonElement>;
+  sortOption: string[];
+  selectedText: string;
+  setSelectedText: React.Dispatch<React.SetStateAction<string>>;
 }
 
 const SortDropdown: React.FC<SortDropdownProps> = ({
+  className,
   clicked,
   setClicked,
   sortButtonRef,
+  sortOption,
+  selectedText,
+  setSelectedText,
 }) => {
-  const sortOption = ['인기순', '리뷰순'];
-  const [SelectedText, setSelectedText] = useState('Event List');
-
-  const handleClick = () => {
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
     if (clicked) {
       setClicked(false);
     } else {
@@ -63,9 +62,9 @@ const SortDropdown: React.FC<SortDropdownProps> = ({
     }
   };
   return (
-    <Wrapper>
+    <div className={className}>
       <Select $clicked={clicked} onClick={handleClick} ref={sortButtonRef}>
-        {SelectedText}
+        {selectedText}
       </Select>
       {clicked ? (
         <Dropdown
@@ -74,7 +73,7 @@ const SortDropdown: React.FC<SortDropdownProps> = ({
           setClicked={setClicked}
         />
       ) : null}
-    </Wrapper>
+    </div>
   );
 };
 

--- a/src/components/modals/AddArtistModal.tsx
+++ b/src/components/modals/AddArtistModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { styled } from 'styled-components';
 
@@ -9,6 +9,7 @@ import { useGetArtistsTypeQuery } from '../../redux/artistsTypeSlice';
 import { useAddImageMutation } from '../../redux/imageSlice';
 import { toggleArtist } from '../../redux/manageModalSlice';
 import { artistType } from '../../types/artistsType';
+import SortDropdown from '../SortButton';
 
 import CommonModal from './CommonModal';
 import { ModalPortal } from './CommonModal';
@@ -59,7 +60,11 @@ const AddArtistModal = () => {
   const [addNewGroup] = useAddArtistsMutation({});
   const { data: artistTypeData } = useGetArtistsTypeQuery();
   const [artistTypeArray, setArtistTypeArray] = useState<artistType[] | []>([]);
-
+  const sortButtonRef = useRef<HTMLButtonElement>(null);
+  const [SortModal, setSortModal] = useState(false);
+  //동적으로 받아오기
+  const sortOption = ['NCT', 'EXO', 'BTS'];
+  const [selectedText, setSelectedText] = useState('그룹');
   useEffect(() => {
     const filteredTypeData = artistTypeData
       ? artistTypeData.filter((data: artistType) => data.id !== 1)
@@ -160,6 +165,15 @@ const AddArtistModal = () => {
             onChange={onChangeGroupImage}
           />
           <div>
+            <GroupSortDropdown
+              className="groupSortdrop"
+              sortButtonRef={sortButtonRef}
+              clicked={SortModal}
+              setClicked={setSortModal}
+              sortOption={sortOption}
+              selectedText={selectedText}
+              setSelectedText={setSelectedText}
+            />
             <NameLabel htmlFor="artistName">
               그룹 이름을 입력해 주세요.
             </NameLabel>
@@ -261,6 +275,10 @@ const ImagePreview = styled.label<imageType>`
   }
 `;
 
+const GroupSortDropdown = styled(SortDropdown)`
+  position: relative;
+  right: 0;
+`;
 const StyledInput = styled.input`
   position: absolute;
   clip: rect(0 0 0 0);
@@ -287,7 +305,6 @@ const NameInput = styled.input`
   width: 360px;
   height: 58px;
   padding: 20px;
-  /* color: #4e5761; */
   font-size: 20px;
   font-weight: 400;
   background-color: #f8f8fa;

--- a/src/components/modals/AddArtistModal.tsx
+++ b/src/components/modals/AddArtistModal.tsx
@@ -1,0 +1,310 @@
+import { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { styled } from 'styled-components';
+
+import closeIcon from '../../assets/icons/close.svg';
+import photoIcon from '../../assets/icons/photo.svg';
+import { useAddArtistsMutation } from '../../redux/artistsSlice';
+import { useGetArtistsTypeQuery } from '../../redux/artistsTypeSlice';
+import { useAddImageMutation } from '../../redux/imageSlice';
+import { toggleArtist } from '../../redux/manageModalSlice';
+import { artistType } from '../../types/artistsType';
+
+import CommonModal from './CommonModal';
+import { ModalPortal } from './CommonModal';
+
+type groupType = {
+  type: string;
+  selected: boolean;
+};
+
+type imageType = {
+  previewimage: string;
+};
+
+type propsType = {
+  data: artistType;
+  selected: boolean;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+const ArtistTypeBtn = ({ data, onChange, selected }: propsType) => {
+  return (
+    <>
+      <TypeLabel
+        htmlFor={data.id.toString()}
+        type={data.type}
+        selected={selected}
+      >
+        {data.type}
+      </TypeLabel>
+      <StyledInput
+        type="radio"
+        id={data.id.toString()}
+        name="artistType"
+        value={data.id.toString()}
+        onChange={onChange}
+      />
+    </>
+  );
+};
+
+const AddArtistModal = () => {
+  const dispatch = useDispatch();
+  const [groupType, setGroupType] = useState(2);
+  const [groupImage, setGroupImage] = useState<File>();
+  const [previewImage, setPreviewImage] = useState<string>('');
+  const [groupName, setGroupName] = useState('');
+  const [addNewImage] = useAddImageMutation({});
+  const [addNewGroup] = useAddArtistsMutation({});
+  const { data: artistTypeData } = useGetArtistsTypeQuery();
+  const [artistTypeArray, setArtistTypeArray] = useState<artistType[] | []>([]);
+
+  useEffect(() => {
+    const filteredTypeData = artistTypeData
+      ? artistTypeData.filter((data: artistType) => data.id !== 1)
+      : [];
+    setArtistTypeArray(filteredTypeData);
+  }, [artistTypeData]);
+
+  const onHideModal = () => {
+    dispatch(toggleArtist());
+  };
+
+  const onClickGroupType = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setGroupType(parseInt(e.target.value));
+  };
+
+  const onChangeGroupName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setGroupName(e.target.value);
+  };
+
+  const onChangeGroupImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      const imgFile = e.target.files[0];
+      //파일 size 확인
+      if (imgFile.size > 1024 ** 2) {
+        alert('앗! 이미지가 너무 커요. 1MB 이하의 사진만 업로드 가능합니다.');
+        return;
+      }
+      setGroupImage(imgFile);
+      setPreviewImage(URL.createObjectURL(imgFile));
+    }
+  };
+
+  const onClickAddGroupBtn = async () => {
+    const formData = new FormData();
+    if (groupImage instanceof File) {
+      formData.append('file', groupImage);
+      try {
+        const response = await addNewImage({
+          imageFile: formData,
+        });
+        if ('error' in response) {
+          return;
+        }
+
+        sendGroupInfo(response.data.filename);
+      } catch (error) {
+        console.error(error);
+      }
+    }
+  };
+
+  const sendGroupInfo = async (imageData: any) => {
+    console.log(imageData);
+    const groupData = {
+      artistTypeId: 1,
+      name: groupName,
+      image: imageData,
+    };
+    try {
+      const response = await addNewGroup(groupData);
+      console.log(response);
+      onHideModal();
+    } catch (error) {
+      console.error(error);
+      alert('앗, 제대로 저장되지 않았어요 다시 시도해주세요');
+    }
+  };
+
+  let content;
+  if (artistTypeArray.length > 0) {
+    content = artistTypeArray.map((data) => (
+      <ArtistTypeBtn
+        key={data.id}
+        data={data}
+        onChange={onClickGroupType}
+        selected={data.id === groupType}
+      />
+    ));
+  }
+
+  return (
+    <ModalPortal>
+      <CommonModal className="addGroupModal" onClick={onHideModal}>
+        <ModalTitle>아티스트 등록하기</ModalTitle>
+        <ModalCloseButton type="button" onClick={onHideModal}>
+          <img src={closeIcon} />
+        </ModalCloseButton>
+        <TypeTitle>아티스트 타입</TypeTitle>
+        <TypeWrapper>{content}</TypeWrapper>
+        <ImageNameWrapper>
+          <ImagePreview htmlFor="artistImage" previewimage={previewImage}>
+            <img src={photoIcon} alt="그룹 이미지 선택" />
+          </ImagePreview>
+          <StyledInput
+            type="file"
+            id="artistImage"
+            accept="image/png, image/jpeg"
+            onChange={onChangeGroupImage}
+          />
+          <div>
+            <NameLabel htmlFor="artistName">
+              그룹 이름을 입력해 주세요.
+            </NameLabel>
+            <NameInput
+              type="text"
+              id="artistName"
+              value={groupName}
+              onChange={onChangeGroupName}
+              placeholder="그룹 이름"
+            />
+          </div>
+        </ImageNameWrapper>
+        <SubmitButton type="button" onClick={onClickAddGroupBtn}>
+          완료
+        </SubmitButton>
+      </CommonModal>
+    </ModalPortal>
+  );
+};
+
+export default AddArtistModal;
+
+const ModalTitle = styled.h4`
+  padding: 13px 58px;
+  margin: 24px 0 22px;
+  background-color: #fcf9a4;
+  border-radius: 73px;
+  border: 2.937px solid var(--line-black);
+  font-size: 28px;
+  font-weight: 700;
+  text-align: center;
+`;
+
+const ModalCloseButton = styled.button`
+  position: absolute;
+  top: 10px;
+  right: 17px;
+`;
+
+const TypeTitle = styled.span`
+  font-size: 24px;
+  font-weight: 700;
+`;
+
+const TypeWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 15px;
+  width: 70%;
+  margin: 10px 0 32px;
+`;
+
+const TypeLabel = styled.label<groupType>`
+  width: 130px;
+  font-size: 20px;
+  font-weight: 400;
+  text-align: center;
+  padding: 10px 20px;
+  border-radius: 30px;
+  box-shadow: 4.4px 4.4px 0px 0px rgba(0, 0, 0, 0.25);
+  cursor: pointer;
+  ${(props) =>
+    props.selected
+      ? `
+      background-color: #f8f8fa;
+      border: 2px solid var(--line-black);
+     `
+      : `
+      color: #8F9196;
+      border: 2.056px solid #8B8E97;
+      background: #EDEDED;
+      `}
+`;
+
+const ImagePreview = styled.label<imageType>`
+  display: block;
+  position: relative;
+  width: 232px;
+  height: 232px;
+  border: 2px solid var(--line-black);
+  border-radius: 30px;
+  text-align: center;
+  cursor: pointer;
+  ${(props) =>
+    props.previewimage
+      ? `
+        background-image: url(${props.previewimage});
+        background-size: cover;
+        background-position: center center;
+        `
+      : `
+        background-color: var(--line-grey2);
+        `}
+  & > img {
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+`;
+
+const StyledInput = styled.input`
+  position: absolute;
+  clip: rect(0 0 0 0);
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+`;
+
+const ImageNameWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 26px;
+`;
+
+const NameLabel = styled.label`
+  display: block;
+  font-size: 24px;
+  font-weight: 700;
+  margin: 10px 20px;
+`;
+const NameInput = styled.input`
+  width: 360px;
+  height: 58px;
+  padding: 20px;
+  /* color: #4e5761; */
+  font-size: 20px;
+  font-weight: 400;
+  background-color: #f8f8fa;
+  border: 1.4px solid var(--font-black);
+  border-radius: 30px;
+  &::placeholder {
+    font-size: 20px;
+    color: 4e5761;
+  }
+`;
+
+const SubmitButton = styled.button`
+  width: 202px;
+  font-size: 35px;
+  font-weight: 700;
+  padding: 16px;
+  border: 3px solid var(--line-black);
+  border-radius: 73px;
+  background-color: #defcf9;
+`;

--- a/src/components/modals/AddArtistModal.tsx
+++ b/src/components/modals/AddArtistModal.tsx
@@ -4,7 +4,10 @@ import { styled } from 'styled-components';
 
 import closeIcon from '../../assets/icons/close.svg';
 import photoIcon from '../../assets/icons/photo.svg';
-import { useAddArtistsMutation } from '../../redux/artistsSlice';
+import {
+  useAddArtistsMutation,
+  useGetArtistsQuery,
+} from '../../redux/artistsSlice';
 import { useGetArtistsTypeQuery } from '../../redux/artistsTypeSlice';
 import { useAddImageMutation } from '../../redux/imageSlice';
 import { toggleArtist } from '../../redux/manageModalSlice';
@@ -50,21 +53,54 @@ const ArtistTypeBtn = ({ data, onChange, selected }: propsType) => {
   );
 };
 
+export type sortOptionsType = {
+  sort: string;
+  id: number;
+};
+
 const AddArtistModal = () => {
   const dispatch = useDispatch();
-  const [groupType, setGroupType] = useState(2);
+  const sortButtonRef = useRef<HTMLButtonElement>(null);
+  //그룹드롭다운
+  const [dropdownText, setDropdownText] = useState<string | null>('그룹');
+  //그룹인 경우 선택될 아이디
+  const [groupId, setGroupId] = useState<number | null>(null);
+  //아티스트의 타입
+  const [artistType, setArtistType] = useState(2);
   const [groupImage, setGroupImage] = useState<File>();
   const [previewImage, setPreviewImage] = useState<string>('');
   const [groupName, setGroupName] = useState('');
+  const [artistTypeArray, setArtistTypeArray] = useState<artistType[] | []>([]);
+  const [SortModal, setSortModal] = useState(false);
+  const [pageNumber, setPageNumber] = useState(0);
+  const [sortOption, setSortOption] = useState<sortOptionsType[]>([]);
+  const pageSize = '20';
   const [addNewImage] = useAddImageMutation({});
   const [addNewGroup] = useAddArtistsMutation({});
   const { data: artistTypeData } = useGetArtistsTypeQuery();
-  const [artistTypeArray, setArtistTypeArray] = useState<artistType[] | []>([]);
-  const sortButtonRef = useRef<HTMLButtonElement>(null);
-  const [SortModal, setSortModal] = useState(false);
-  //동적으로 받아오기
-  const sortOption = ['NCT', 'EXO', 'BTS'];
-  const [selectedText, setSelectedText] = useState('그룹');
+  const { data: groupArtist } = useGetArtistsQuery({
+    artistTypeId: '1',
+    pageNumber: pageNumber.toString(),
+    pageSize,
+  });
+
+  setPageNumber;
+  groupArtist;
+  groupId;
+  useEffect(() => {
+    console.log(groupId);
+  }, [groupId]);
+
+  useEffect(() => {
+    if (groupArtist) {
+      const groupData = groupArtist.content.map((group) => ({
+        sort: group.name,
+        id: group.id,
+      }));
+      setSortOption(groupData);
+    }
+  }, [groupArtist]);
+
   useEffect(() => {
     const filteredTypeData = artistTypeData
       ? artistTypeData.filter((data: artistType) => data.id !== 1)
@@ -77,7 +113,7 @@ const AddArtistModal = () => {
   };
 
   const onClickGroupType = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setGroupType(parseInt(e.target.value));
+    setArtistType(parseInt(e.target.value));
   };
 
   const onChangeGroupName = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -140,7 +176,7 @@ const AddArtistModal = () => {
         key={data.id}
         data={data}
         onChange={onClickGroupType}
-        selected={data.id === groupType}
+        selected={data.id === artistType}
       />
     ));
   }
@@ -170,9 +206,10 @@ const AddArtistModal = () => {
               sortButtonRef={sortButtonRef}
               clicked={SortModal}
               setClicked={setSortModal}
-              sortOption={sortOption}
-              selectedText={selectedText}
-              setSelectedText={setSelectedText}
+              sortOptions={sortOption}
+              selectedText={dropdownText}
+              setSelectedText={setDropdownText}
+              setId={setGroupId}
             />
             <NameLabel htmlFor="artistName">
               그룹 이름을 입력해 주세요.

--- a/src/components/modals/AddArtistModal.tsx
+++ b/src/components/modals/AddArtistModal.tsx
@@ -67,29 +67,24 @@ const AddArtistModal = () => {
   const [groupId, setGroupId] = useState<number | null>(null);
   //아티스트의 타입
   const [artistType, setArtistType] = useState(2);
-  const [groupImage, setGroupImage] = useState<File>();
+  const [artistImage, setArtistImage] = useState<File>();
   const [previewImage, setPreviewImage] = useState<string>('');
-  const [groupName, setGroupName] = useState('');
+  const [artistName, setArtistName] = useState('');
   const [artistTypeArray, setArtistTypeArray] = useState<artistType[] | []>([]);
   const [SortModal, setSortModal] = useState(false);
-  const [pageNumber, setPageNumber] = useState(0);
+  const [groupPageNumber, setGroupPageNumber] = useState(0);
   const [sortOption, setSortOption] = useState<sortOptionsType[]>([]);
   const pageSize = '20';
   const [addNewImage] = useAddImageMutation({});
-  const [addNewGroup] = useAddArtistsMutation({});
   const { data: artistTypeData } = useGetArtistsTypeQuery();
   const { data: groupArtist } = useGetArtistsQuery({
     artistTypeId: '1',
-    pageNumber: pageNumber.toString(),
+    pageNumber: groupPageNumber.toString(),
     pageSize,
   });
+  const [addNewArtist] = useAddArtistsMutation({});
 
-  setPageNumber;
-  groupArtist;
-  groupId;
-  useEffect(() => {
-    console.log(groupId);
-  }, [groupId]);
+  setGroupPageNumber;
 
   useEffect(() => {
     if (groupArtist) {
@@ -116,11 +111,11 @@ const AddArtistModal = () => {
     setArtistType(parseInt(e.target.value));
   };
 
-  const onChangeGroupName = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setGroupName(e.target.value);
+  const onChangeArtistName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setArtistName(e.target.value);
   };
 
-  const onChangeGroupImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onChangeArtistImage = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
       const imgFile = e.target.files[0];
       //파일 size 확인
@@ -128,15 +123,15 @@ const AddArtistModal = () => {
         alert('앗! 이미지가 너무 커요. 1MB 이하의 사진만 업로드 가능합니다.');
         return;
       }
-      setGroupImage(imgFile);
+      setArtistImage(imgFile);
       setPreviewImage(URL.createObjectURL(imgFile));
     }
   };
 
-  const onClickAddGroupBtn = async () => {
+  const onClickAddArtistBtn = async () => {
     const formData = new FormData();
-    if (groupImage instanceof File) {
-      formData.append('file', groupImage);
+    if (artistImage instanceof File) {
+      formData.append('file', artistImage);
       try {
         const response = await addNewImage({
           imageFile: formData,
@@ -144,7 +139,6 @@ const AddArtistModal = () => {
         if ('error' in response) {
           return;
         }
-
         sendGroupInfo(response.data.filename);
       } catch (error) {
         console.error(error);
@@ -152,15 +146,16 @@ const AddArtistModal = () => {
     }
   };
 
-  const sendGroupInfo = async (imageData: any) => {
+  const sendGroupInfo = async (imageData: string) => {
     console.log(imageData);
-    const groupData = {
-      artistTypeId: 1,
-      name: groupName,
+    const artistData = {
+      artistTypeId: artistType,
+      groupId,
+      name: artistName,
       image: imageData,
     };
     try {
-      const response = await addNewGroup(groupData);
+      const response = await addNewArtist(artistData);
       console.log(response);
       onHideModal();
     } catch (error) {
@@ -192,13 +187,13 @@ const AddArtistModal = () => {
         <TypeWrapper>{content}</TypeWrapper>
         <ImageNameWrapper>
           <ImagePreview htmlFor="artistImage" previewimage={previewImage}>
-            <img src={photoIcon} alt="그룹 이미지 선택" />
+            <img src={photoIcon} alt="아티스트 이미지 선택" />
           </ImagePreview>
           <StyledInput
             type="file"
             id="artistImage"
             accept="image/png, image/jpeg"
-            onChange={onChangeGroupImage}
+            onChange={onChangeArtistImage}
           />
           <div>
             <GroupSortDropdown
@@ -212,18 +207,18 @@ const AddArtistModal = () => {
               setId={setGroupId}
             />
             <NameLabel htmlFor="artistName">
-              그룹 이름을 입력해 주세요.
+              아티스트 이름을 입력해 주세요.
             </NameLabel>
             <NameInput
               type="text"
               id="artistName"
-              value={groupName}
-              onChange={onChangeGroupName}
-              placeholder="그룹 이름"
+              value={artistName}
+              onChange={onChangeArtistName}
+              placeholder="아티스트 이름"
             />
           </div>
         </ImageNameWrapper>
-        <SubmitButton type="button" onClick={onClickAddGroupBtn}>
+        <SubmitButton type="button" onClick={onClickAddArtistBtn}>
           완료
         </SubmitButton>
       </CommonModal>

--- a/src/components/modals/AddGroupModal.tsx
+++ b/src/components/modals/AddGroupModal.tsx
@@ -11,16 +11,11 @@ import { toggleGroup } from '../../redux/manageModalSlice';
 import CommonModal from './CommonModal';
 import { ModalPortal } from './CommonModal';
 
-// type groupType = {
-//   type: string;
-// };
-
 type imageType = {
   previewimage: string;
 };
 
 const AddGroupModal = () => {
-  // const [groupType, setGroupType] = useState('group');
   const [groupImage, setGroupImage] = useState<File>();
   const [previewImage, setPreviewImage] = useState<string>('');
   const [groupName, setGroupName] = useState('');
@@ -31,10 +26,6 @@ const AddGroupModal = () => {
   const onHideModal = () => {
     dispatch(toggleGroup());
   };
-
-  // const onClickGroupType = (e: React.ChangeEvent<HTMLInputElement>) => {
-  //   setGroupType(e.target.value);
-  // };
 
   const onChangeGroupName = (e: React.ChangeEvent<HTMLInputElement>) => {
     setGroupName(e.target.value);
@@ -96,30 +87,6 @@ const AddGroupModal = () => {
         <ModalCloseButton type="button" onClick={onHideModal}>
           <img src={closeIcon} />
         </ModalCloseButton>
-        {/* <TypeTitle>아티스트 타입</TypeTitle>
-        <TypeWrapper>
-          <GroupTypeLabel htmlFor="group" type={groupType}>
-            그룹
-          </GroupTypeLabel>
-          <StyledInput
-            type="radio"
-            id="group"
-            name="artistType"
-            value="group"
-            onChange={onClickGroupType}
-            // defaultChecked
-          />
-          <ArtistTypeLabel htmlFor="artist" type={groupType}>
-            아티스트
-          </ArtistTypeLabel>
-          <StyledInput
-            type="radio"
-            id="artist"
-            name="artistType"
-            value="artist"
-            onChange={onClickGroupType}
-          />
-        </TypeWrapper> */}
         <ImageNameWrapper>
           <ImagePreview htmlFor="artistImage" previewimage={previewImage}>
             <img src={photoIcon} alt="그룹 이미지 선택" />
@@ -170,55 +137,6 @@ const ModalCloseButton = styled.button`
   top: 10px;
   right: 17px;
 `;
-
-// const TypeTitle = styled.span`
-//   font-size: 24px;
-//   font-weight: 700;
-// `;
-
-// const TypeWrapper = styled.div`
-//   display: flex;
-//   justify-content: center;
-//   gap: 15px;
-//   margin: 10px 0 32px;
-// `;
-
-// const TypeLabel = styled.label`
-//   width: 130px;
-//   font-size: 20px;
-//   font-weight: 400;
-//   text-align: center;
-//   padding: 10px 20px;
-//   border-radius: 30px;
-//   border: 2px solid var(--line-black);
-//   background: #f8f8fa;
-//   box-shadow: 4.4px 4.4px 0px 0px rgba(0, 0, 0, 0.25);
-//   cursor: pointer;
-`;
-
-// const ArtistTypeLabel = styled(TypeLabel)<groupType>`;
-//   ${(props) =>
-//     props.type === 'group'
-//       ? ``
-//       : `
-//         color: #8F9196;
-//         border-radius: 30px;
-//         border: 2.056px solid #8B8E97;
-//         background: #EDEDED;
-//         `}
-// `;
-
-// const GroupTypeLabel = styled(TypeLabel)<groupType>`
-//   ${(props) =>
-//     props.type === 'group'
-//       ? `
-//         color: #8F9196;
-//         border-radius: 30px;
-//         border: 2.056px solid var(--unnamed, #8B8E97);
-//         background: var(--unnamed, #EDEDED);
-//         `
-//       : ``}
-// `;
 
 const ImagePreview = styled.label<imageType>`
   display: block;
@@ -272,7 +190,6 @@ const NameInput = styled.input`
   width: 360px;
   height: 58px;
   padding: 20px;
-  /* color: #4e5761; */
   font-size: 20px;
   font-weight: 400;
   background-color: #f8f8fa;

--- a/src/components/modals/CommonModal.tsx
+++ b/src/components/modals/CommonModal.tsx
@@ -43,7 +43,7 @@ const ModalOverlay = styled.form`
   justify-content: center;
   width: 960px;
   top: 5vh;
-  padding: 50px 20px 50px;
+  padding: 50px 20px 36px;
   margin: 0 auto;
   border: 3px solid var(--line-black);
   border-radius: 29px;

--- a/src/layout/GeneralLayout.tsx
+++ b/src/layout/GeneralLayout.tsx
@@ -3,8 +3,10 @@ import { styled } from 'styled-components';
 
 import Billboard from '../components/Billboard';
 import Header from '../components/Header';
+import AddArtistModal from '../components/modals/AddArtistModal';
 import AddGroupModal from '../components/modals/AddGroupModal';
 import { selectGroupModalState } from '../redux/manageModalSlice';
+import { selectArtistModalState } from '../redux/manageModalSlice';
 
 interface GeneralLayoutProps {
   children: React.ReactNode;
@@ -17,11 +19,13 @@ const PageWrapper = styled.section`
 
 const GeneralLayout: React.FC<GeneralLayoutProps> = ({ children }) => {
   const groupModalState = useSelector(selectGroupModalState);
+  const artistModalState = useSelector(selectArtistModalState);
 
   return (
     <PageWrapper>
       <Billboard />
       {groupModalState && <AddGroupModal />}
+      {artistModalState && <AddArtistModal />}
       <Header />
       {children}
     </PageWrapper>

--- a/src/pages/ManagePage/ArtistListItem.tsx
+++ b/src/pages/ManagePage/ArtistListItem.tsx
@@ -13,10 +13,12 @@ import {
   ArtistName,
 } from './ArtistListItemStyle';
 
-const testImg =
-  'https://images.unsplash.com/photo-1567880905822-56f8e06fe630?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=735&q=80';
-
 const ArtistListItem = ({ data }: { data: ArtistContent }) => {
+  //test data용 image
+  const testImg =
+    'https://images.unsplash.com/photo-1567880905822-56f8e06fe630?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=735&q=80';
+  const artistImage = data.image !== '/images/null' ? data.image : testImg;
+
   return (
     <ListItem>
       <ListItemTitle>
@@ -29,7 +31,7 @@ const ArtistListItem = ({ data }: { data: ArtistContent }) => {
         </CommonButton>
       </ListItemTitle>
       <ArtistImgContainer>
-        <ArtistImg src={testImg} />
+        <ArtistImg image={artistImage} />
       </ArtistImgContainer>
     </ListItem>
   );

--- a/src/pages/ManagePage/ArtistListItemStyle.tsx
+++ b/src/pages/ManagePage/ArtistListItemStyle.tsx
@@ -1,5 +1,9 @@
 import { styled } from 'styled-components';
 
+type imgType = {
+  image: string;
+};
+
 export const ListItem = styled.article`
   width: 214px;
   margin: 0 auto;
@@ -57,6 +61,7 @@ export const CommonButton = styled.button`
 `;
 
 export const ArtistImgContainer = styled.div`
+  position: relative;
   width: 100%;
   height: 155px;
   overflow: hidden;
@@ -65,8 +70,9 @@ export const ArtistImgContainer = styled.div`
   border-bottom: 2px solid var(--line-black);
 `;
 
-export const ArtistImg = styled.img`
-  top: 50%;
-  bottom: 50%;
-  transform: translate(-50%, -50%);
+export const ArtistImg = styled.div<imgType>`
+  height: 100%;
+  background-image: url(${(props) => props.image});
+  background-position: center;
+  background-size: cover;
 `;

--- a/src/pages/ManagePage/Manage.tsx
+++ b/src/pages/ManagePage/Manage.tsx
@@ -21,7 +21,11 @@ import {
 const Manage = () => {
   const [artistsArray, setArtistsArray] = useState<ArtistContent[]>([]);
   const [artistlistPage, setArtistListPage] = useState(0);
+  //아티스트 타입별로 조회 시 사용
   const [artistType, setArtistType] = useState('');
+  //api에 디폴트값 생기면 삭제할 코드
+  const [pageSize] = useState(20);
+  //삭제 예정 코드
   useEffect(() => {
     setArtistType('');
   }, []);
@@ -34,7 +38,8 @@ const Manage = () => {
     error,
   } = useGetArtistsQuery({
     artistTypeId: artistType,
-    page: artistlistPage.toString(),
+    pageNumber: artistlistPage.toString(),
+    pageSize: pageSize.toString(),
   });
 
   useEffect(() => {

--- a/src/pages/mainPage/Main.tsx
+++ b/src/pages/mainPage/Main.tsx
@@ -24,8 +24,12 @@ interface Reviews {
 const Main = () => {
   const sortButtonRef = useRef<HTMLButtonElement>(null);
   const [SortModal, setSortModal] = useState(false);
-  const sortOption = ['인기순', '리뷰순'];
-  const [SelectedText, setSelectedText] = useState('Event List');
+  const sortOption = [
+    { id: 1, sort: '인기순' },
+    { id: 2, sort: '리뷰순' },
+  ];
+  const [SelectedText, setSelectedText] = useState<string | null>('Event List');
+  const [_, setSelectedId] = useState<number | null>(null);
   // TODO: 추가된 API로 수정해서 리뷰 이미지 목록 불러오기
   // const [reviewImages, setReviewImages] = useState<Reviews[]>([]);
 
@@ -68,9 +72,10 @@ const Main = () => {
             sortButtonRef={sortButtonRef}
             clicked={SortModal}
             setClicked={setSortModal}
-            sortOption={sortOption}
+            sortOptions={sortOption}
             selectedText={SelectedText}
             setSelectedText={setSelectedText}
+            setId={setSelectedId}
           />
           <MapTitle>지도</MapTitle>
           <MapSection />

--- a/src/pages/mainPage/Main.tsx
+++ b/src/pages/mainPage/Main.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 
 // import { reveiws } from '../../api/event';
-import SortDropdown from '../../components/SortButton';
+// import SortDropdown from '../../components/SortButton';
 
 import {
   MainSection,
@@ -9,6 +9,7 @@ import {
   ViewReviews,
   MoreButton,
   Reviews,
+  MapSortDrop,
   MapFrame,
   MapTitle,
   ViewReviewsTitle,
@@ -23,6 +24,8 @@ interface Reviews {
 const Main = () => {
   const sortButtonRef = useRef<HTMLButtonElement>(null);
   const [SortModal, setSortModal] = useState(false);
+  const sortOption = ['인기순', '리뷰순'];
+  const [SelectedText, setSelectedText] = useState('Event List');
   // TODO: 추가된 API로 수정해서 리뷰 이미지 목록 불러오기
   // const [reviewImages, setReviewImages] = useState<Reviews[]>([]);
 
@@ -60,10 +63,14 @@ const Main = () => {
     <>
       <MainSection>
         <MapFrame>
-          <SortDropdown
+          <MapSortDrop
+            className="mainSortdrop"
             sortButtonRef={sortButtonRef}
             clicked={SortModal}
             setClicked={setSortModal}
+            sortOption={sortOption}
+            selectedText={SelectedText}
+            setSelectedText={setSelectedText}
           />
           <MapTitle>지도</MapTitle>
           <MapSection />

--- a/src/pages/mainPage/MainStyle.tsx
+++ b/src/pages/mainPage/MainStyle.tsx
@@ -1,6 +1,8 @@
 import { styled } from 'styled-components';
 
 import ReviewPreviewIcon from '../../assets/review-preview-icon.svg';
+import SortDropdown from '../../components/SortButton';
+import { SortDropdownProps } from '../../components/SortButton';
 import px2vw from '../../utils/px2vw';
 
 export const TextButton = styled.button`
@@ -29,7 +31,14 @@ export const MainSection = styled.main`
   position: relative;
 `;
 
+export const MapSortDrop = styled(SortDropdown)<SortDropdownProps>`
+  position: absolute;
+  right: 40px;
+  top: 40px;
+`;
+
 export const MapFrame = styled.section`
+  position: relative;
   width: 100%;
   padding: 27px 22px 15px 25px;
   border: 2px solid #000000;

--- a/src/redux/apiSlice.ts
+++ b/src/redux/apiSlice.ts
@@ -7,13 +7,11 @@ export const apiSlice = createApi({
   baseQuery: fetchBaseQuery({
     //cors 에러 처리 후 proxy 삭제 시 활성화
     // baseUrl,
-    prepareHeaders: (headers) => {
-      headers.set('Content-Type', 'application/json');
-      headers.set('Accept', 'application/json');
-
-      return headers;
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
     },
   }),
-  tagTypes: ['ArtistType', 'Artists'],
+  tagTypes: ['ArtistType', 'Artists', 'Images'],
   endpoints: () => ({}),
 });

--- a/src/redux/artistsSlice.ts
+++ b/src/redux/artistsSlice.ts
@@ -40,7 +40,7 @@ export const artistsApiSlice = apiSlice.injectEndpoints({
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
-        body: { artistValue },
+        body: artistValue,
       }),
       invalidatesTags: ['Artists'],
     }),

--- a/src/redux/artistsSlice.ts
+++ b/src/redux/artistsSlice.ts
@@ -9,11 +9,10 @@ export const artistsApiSlice = apiSlice.injectEndpoints({
     getArtists: builder.query<
       ArtistsData,
       {
-        artistTypeId: string;
+        artistTypeId?: string;
         artistName?: string | undefined;
-        page: string;
-        size?: string | undefined;
-        sort?: string | undefined;
+        pageNumber: string;
+        pageSize: string;
       }
     >({
       query: (params) => {

--- a/src/redux/artistsTypeSlice.ts
+++ b/src/redux/artistsTypeSlice.ts
@@ -1,13 +1,13 @@
-import useLocalStorage from '../hooks/useLocalStarage';
+import { artistType } from '../types/artistsType';
 
 import { apiSlice } from './apiSlice';
 
-const [accessToken] = useLocalStorage('admin', null);
+const accessToken = window.localStorage.getItem('admin');
 
 export const artistsTypeApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
-    getArtistsType: builder.query({
-      query: () => '/artists/type',
+    getArtistsType: builder.query<artistType[], void>({
+      query: () => '/artists/types',
       providesTags: ['ArtistType'],
     }),
     addArtistsType: builder.mutation({

--- a/src/redux/imageSlice.ts
+++ b/src/redux/imageSlice.ts
@@ -1,0 +1,26 @@
+import { apiSlice } from './apiSlice';
+
+type ImageData = {
+  filename: string;
+};
+export const imageSlice = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    getImage: builder.query({
+      query: (fileName: string) => ({
+        url: `/images/${fileName}`,
+        providesTags: ['Images'],
+      }),
+    }),
+    addImage: builder.mutation<ImageData, { imageFile: FormData }>({
+      query: ({ imageFile }) => ({
+        url: '/images',
+        method: 'POST',
+        headers: {},
+        body: imageFile,
+      }),
+      invalidatesTags: ['Images'],
+    }),
+  }),
+});
+
+export const { useGetImageQuery, useAddImageMutation } = imageSlice;

--- a/src/types/artistsType.ts
+++ b/src/types/artistsType.ts
@@ -1,6 +1,6 @@
 export interface ArtistValue {
   artistTypeId: number;
-  groupId: number;
+  groupId?: number;
   name: string;
   image: string;
 }

--- a/src/types/artistsType.ts
+++ b/src/types/artistsType.ts
@@ -1,6 +1,6 @@
 export interface ArtistValue {
   artistTypeId: number;
-  groupId?: number;
+  groupId?: number | null;
   name: string;
   image: string;
 }

--- a/src/types/artistsType.ts
+++ b/src/types/artistsType.ts
@@ -5,6 +5,11 @@ export interface ArtistValue {
   image: string;
 }
 
+export type artistType = {
+  id: number;
+  type: string;
+};
+
 export interface ArtistsData {
   totalElements: number;
   totalPages: number;


### PR DESCRIPTION
## Describe your changes

관리자 페이지
- 이미지 조회/저장 api 연동
- 그룹 등록 모달 기능 구현
- 아티스트 등록 모달 UI 및 아티스트 등록 기능 구현

## To-do before merge

- (메인에서 사용하셨던) 드롭다운을 아티스트 등록 모달에서 재사용하기 위해서 코드 수정을 했습니다. 예징이 님이 작성하셨던 Main, Dropdown, SortButton 파일에서 스타일링이랑 추가적인 props를 내려주는 등의 수정이 있습니다. 기능은 전과 다름없는 걸 확인했는데, 혹시 바뀐 코드에 문제나 질문 있으시면 언제든 말해주세요!!
- 아티스트 조회해 올 때 중복 데이터가 보여지는 버그가 있습니다. 어떻게 처리해야할 지는 생각중입니다...🥲 시간이 좀 소요될 거 같은 점, PR 크기가 너무너무 커질 거 같은 점 때문에 이대로 PR 요청합니당!
