### PR TITLE
이벤트카테고리/아티스트 타입 등록 및 아티스트 삭제 기능

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,6 +14,7 @@ import { TextButton } from '../pages/mainPage/MainStyle';
 import { toggleGroup } from '../redux/manageModalSlice';
 import { toggleArtist } from '../redux/manageModalSlice';
 import { toggleCategory } from '../redux/manageModalSlice';
+import { toggleArtistType } from '../redux/manageModalSlice';
 import px2vw from '../utils/px2vw';
 
 export const HeaderStyle = styled.header`
@@ -102,6 +103,9 @@ const Header: React.FC = ({}) => {
   const handleArtistClick = () => {
     dispatch(toggleArtist());
   };
+  const handleArtistTypeClick = () => {
+    dispatch(toggleArtistType());
+  };
   const handleCategoryClick = () => {
     dispatch(toggleCategory());
   };
@@ -125,6 +129,12 @@ const Header: React.FC = ({}) => {
     },
     {
       id: 2,
+      title: '아티스트 타입 등록',
+      icon: settingIcon,
+      handler: handleArtistTypeClick,
+    },
+    {
+      id: 3,
       title: '카테고리 등록',
       icon: settingIcon,
       handler: handleCategoryClick,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,6 +13,7 @@ import { useRouter } from '../hooks/useRouter';
 import { TextButton } from '../pages/mainPage/MainStyle';
 import { toggleGroup } from '../redux/manageModalSlice';
 import { toggleArtist } from '../redux/manageModalSlice';
+import { toggleCategory } from '../redux/manageModalSlice';
 import px2vw from '../utils/px2vw';
 
 export const HeaderStyle = styled.header`
@@ -101,9 +102,8 @@ const Header: React.FC = ({}) => {
   const handleArtistClick = () => {
     dispatch(toggleArtist());
   };
-
   const handleCategoryClick = () => {
-    console.log('카테고리 등록!');
+    dispatch(toggleCategory());
   };
 
   const publicMenu = [

--- a/src/components/modals/AddArtistModal.tsx
+++ b/src/components/modals/AddArtistModal.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { styled } from 'styled-components';
 
 import closeIcon from '../../assets/icons/close.svg';
 import photoIcon from '../../assets/icons/photo.svg';
@@ -12,46 +11,23 @@ import { useGetArtistsTypeQuery } from '../../redux/artistsTypeSlice';
 import { useAddImageMutation } from '../../redux/imageSlice';
 import { toggleArtist } from '../../redux/manageModalSlice';
 import { artistType } from '../../types/artistsType';
-import SortDropdown from '../SortButton';
 
+import {
+  ModalTitle,
+  ModalCloseButton,
+  TypeTitle,
+  TypeWrapper,
+  ImageNameWrapper,
+  ImagePreview,
+  NameInput,
+  NameLabel,
+  SubmitButton,
+  StyledInput,
+  GroupSortDropdown,
+} from './AddArtistModalStyle';
 import CommonModal from './CommonModal';
 import { ModalPortal } from './CommonModal';
-
-type groupType = {
-  type: string;
-  selected: boolean;
-};
-
-type imageType = {
-  previewimage: string;
-};
-
-type propsType = {
-  data: artistType;
-  selected: boolean;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-};
-
-const ArtistTypeBtn = ({ data, onChange, selected }: propsType) => {
-  return (
-    <>
-      <TypeLabel
-        htmlFor={data.id.toString()}
-        type={data.type}
-        selected={selected}
-      >
-        {data.type}
-      </TypeLabel>
-      <StyledInput
-        type="radio"
-        id={data.id.toString()}
-        name="artistType"
-        value={data.id.toString()}
-        onChange={onChange}
-      />
-    </>
-  );
-};
+import TypeButton from './components/TypeButton';
 
 export type sortOptionsType = {
   sort: string;
@@ -165,7 +141,7 @@ const AddArtistModal = () => {
   let content;
   if (artistTypeArray.length > 0) {
     content = artistTypeArray.map((data) => (
-      <ArtistTypeBtn
+      <TypeButton
         key={data.id}
         data={data}
         onChange={onClickGroupType}
@@ -225,133 +201,3 @@ const AddArtistModal = () => {
 };
 
 export default AddArtistModal;
-
-const ModalTitle = styled.h4`
-  padding: 13px 58px;
-  margin: 24px 0 22px;
-  background-color: #fcf9a4;
-  border-radius: 73px;
-  border: 2.937px solid var(--line-black);
-  font-size: 28px;
-  font-weight: 700;
-  text-align: center;
-`;
-
-const ModalCloseButton = styled.button`
-  position: absolute;
-  top: 10px;
-  right: 17px;
-`;
-
-const TypeTitle = styled.span`
-  font-size: 24px;
-  font-weight: 700;
-`;
-
-const TypeWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 15px;
-  width: 70%;
-  margin: 10px 0 32px;
-`;
-
-const TypeLabel = styled.label<groupType>`
-  width: 130px;
-  font-size: 20px;
-  font-weight: 400;
-  text-align: center;
-  padding: 10px 20px;
-  border-radius: 30px;
-  box-shadow: 4.4px 4.4px 0px 0px rgba(0, 0, 0, 0.25);
-  cursor: pointer;
-  ${(props) =>
-    props.selected
-      ? `
-      background-color: #f8f8fa;
-      border: 2px solid var(--line-black);
-     `
-      : `
-      color: #8F9196;
-      border: 2.056px solid #8B8E97;
-      background: #EDEDED;
-      `}
-`;
-
-const ImagePreview = styled.label<imageType>`
-  display: block;
-  position: relative;
-  width: 232px;
-  height: 232px;
-  border: 2px solid var(--line-black);
-  border-radius: 30px;
-  text-align: center;
-  cursor: pointer;
-  ${(props) =>
-    props.previewimage
-      ? `
-        background-image: url(${props.previewimage});
-        background-size: cover;
-        background-position: center center;
-        `
-      : `
-        background-color: var(--line-grey2);
-        `}
-  & > img {
-    position: relative;
-    top: 50%;
-    transform: translateY(-50%);
-  }
-`;
-
-const GroupSortDropdown = styled(SortDropdown)`
-  position: relative;
-  right: 0;
-`;
-const StyledInput = styled.input`
-  position: absolute;
-  clip: rect(0 0 0 0);
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-`;
-
-const ImageNameWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  margin-bottom: 26px;
-`;
-
-const NameLabel = styled.label`
-  display: block;
-  font-size: 24px;
-  font-weight: 700;
-  margin: 10px 20px;
-`;
-const NameInput = styled.input`
-  width: 360px;
-  height: 58px;
-  padding: 20px;
-  font-size: 20px;
-  font-weight: 400;
-  background-color: #f8f8fa;
-  border: 1.4px solid var(--font-black);
-  border-radius: 30px;
-  &::placeholder {
-    font-size: 20px;
-    color: 4e5761;
-  }
-`;
-
-const SubmitButton = styled.button`
-  width: 202px;
-  font-size: 35px;
-  font-weight: 700;
-  padding: 16px;
-  border: 3px solid var(--line-black);
-  border-radius: 73px;
-  background-color: #defcf9;
-`;

--- a/src/components/modals/AddArtistModal.tsx
+++ b/src/components/modals/AddArtistModal.tsx
@@ -144,6 +144,7 @@ const AddArtistModal = () => {
       <TypeButton
         key={data.id}
         data={data}
+        text={data.type}
         onChange={onClickGroupType}
         selected={data.id === artistType}
       />

--- a/src/components/modals/AddArtistModal.tsx
+++ b/src/components/modals/AddArtistModal.tsx
@@ -139,15 +139,14 @@ const AddArtistModal = () => {
         if ('error' in response) {
           return;
         }
-        sendGroupInfo(response.data.filename);
+        sendArtistInfo(response.data.filename);
       } catch (error) {
         console.error(error);
       }
     }
   };
 
-  const sendGroupInfo = async (imageData: string) => {
-    console.log(imageData);
+  const sendArtistInfo = async (imageData: string) => {
     const artistData = {
       artistTypeId: artistType,
       groupId,
@@ -155,8 +154,7 @@ const AddArtistModal = () => {
       image: imageData,
     };
     try {
-      const response = await addNewArtist(artistData);
-      console.log(response);
+      await addNewArtist(artistData);
       onHideModal();
     } catch (error) {
       console.error(error);

--- a/src/components/modals/AddArtistModalStyle.tsx
+++ b/src/components/modals/AddArtistModalStyle.tsx
@@ -1,0 +1,117 @@
+import styled from 'styled-components';
+
+import SortDropdown from '../SortButton';
+
+type imageType = {
+  previewimage: string;
+};
+
+export const ModalTitle = styled.h4`
+  padding: 13px 58px;
+  margin: 24px 0 22px;
+  background-color: #fcf9a4;
+  border-radius: 73px;
+  border: 2.937px solid var(--line-black);
+  font-size: 28px;
+  font-weight: 700;
+  text-align: center;
+`;
+
+export const ModalCloseButton = styled.button`
+  position: absolute;
+  top: 10px;
+  right: 17px;
+`;
+
+export const TypeTitle = styled.span`
+  font-size: 24px;
+  font-weight: 700;
+`;
+
+export const TypeWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 15px;
+  width: 70%;
+  margin: 10px 0 32px;
+`;
+
+export const ImagePreview = styled.label<imageType>`
+  display: block;
+  position: relative;
+  width: 232px;
+  height: 232px;
+  border: 2px solid var(--line-black);
+  border-radius: 30px;
+  text-align: center;
+  cursor: pointer;
+  ${(props) =>
+    props.previewimage
+      ? `
+      background-image: url(${props.previewimage});
+      background-size: cover;
+      background-position: center center;
+      `
+      : `
+      background-color: var(--line-grey2);
+      `}
+  & > img {
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+`;
+
+export const GroupSortDropdown = styled(SortDropdown)`
+  position: relative;
+  right: 0;
+`;
+
+export const StyledInput = styled.input`
+  position: absolute;
+  clip: rect(0 0 0 0);
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+`;
+
+export const ImageNameWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 26px;
+`;
+
+export const NameLabel = styled.label`
+  display: block;
+  font-size: 24px;
+  font-weight: 700;
+  margin: 10px 20px;
+`;
+
+export const NameInput = styled.input`
+  width: 360px;
+  height: 58px;
+  padding: 20px;
+  font-size: 20px;
+  font-weight: 400;
+  background-color: #f8f8fa;
+  border: 1.4px solid var(--font-black);
+  border-radius: 30px;
+  &::placeholder {
+    font-size: 20px;
+    color: 4e5761;
+  }
+`;
+
+export const SubmitButton = styled.button`
+  width: 202px;
+  font-size: 35px;
+  font-weight: 700;
+  padding: 16px;
+  border: 3px solid var(--line-black);
+  border-radius: 73px;
+  background-color: #defcf9;
+`;

--- a/src/components/modals/AddArtistTypeModal.tsx
+++ b/src/components/modals/AddArtistTypeModal.tsx
@@ -2,11 +2,9 @@ import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import closeIcon from '../../assets/icons/close.svg';
-import {
-  useGetEventCategoryQuery,
-  useAddEventCategoryMutation,
-} from '../../redux/eventCategoryType';
-import { toggleCategory } from '../../redux/manageModalSlice';
+import { useGetArtistsTypeQuery } from '../../redux/artistsTypeSlice';
+import { useAddArtistsTypeMutation } from '../../redux/artistsTypeSlice';
+import { toggleArtistType } from '../../redux/manageModalSlice';
 
 import {
   ModalTitle,
@@ -20,27 +18,30 @@ import CommonModal from './CommonModal';
 import { ModalPortal } from './CommonModal';
 import TypeButton from './components/TypeButton';
 
-type categoryType = {
+type artistType = {
   id: number;
-  category: string;
+  type: string;
 };
-const AddCategoryModal = () => {
-  const [categoryName, setCategoryName] = useState('');
-  const [categoryContents, setCategoryContents] = useState<categoryType[]>([]);
+const AddArtistTypeModal = () => {
+  const [typeName, setTypeName] = useState('');
+  const [artistTypeContents, setArtistTypeContents] = useState<artistType[]>(
+    []
+  );
   const dispatch = useDispatch();
-  const { data: eventCategories } = useGetEventCategoryQuery();
-  const [addNewCategory] = useAddEventCategoryMutation();
+  const { data: artistTypes } = useGetArtistsTypeQuery();
+  const [addNewArtistType] = useAddArtistsTypeMutation();
+
   const onHideModal = () => {
-    dispatch(toggleCategory());
+    dispatch(toggleArtistType());
   };
 
-  const onChangeCategoryName = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setCategoryName(e.target.value);
+  const onChangeTypeName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTypeName(e.target.value);
   };
 
-  const onClickAddCategoryBtn = async () => {
+  const onClickAddTypeBtn = async () => {
     try {
-      await addNewCategory(categoryName);
+      await addNewArtistType(typeName);
       onHideModal();
     } catch (error) {
       console.error(error);
@@ -49,16 +50,16 @@ const AddCategoryModal = () => {
   };
 
   useEffect(() => {
-    if (eventCategories) setCategoryContents(eventCategories);
-  }, [eventCategories]);
+    if (artistTypes) setArtistTypeContents(artistTypes);
+  }, [artistTypes]);
 
   let typeContents;
-  if (categoryContents.length > 0) {
-    typeContents = categoryContents.map((content) => (
+  if (artistTypeContents.length > 0) {
+    typeContents = artistTypeContents.map((content) => (
       <TypeButton
         key={content.id}
         data={content}
-        text={content.category}
+        text={content.type}
         selected={true}
       />
     ));
@@ -67,20 +68,22 @@ const AddCategoryModal = () => {
   return (
     <ModalPortal>
       <CommonModal className="addGroupModal" onClick={onHideModal}>
-        <ModalTitle>카테고리 등록하기</ModalTitle>
+        <ModalTitle>아티스트 타입 등록하기</ModalTitle>
         <ModalCloseButton type="button" onClick={onHideModal}>
           <img src={closeIcon} />
         </ModalCloseButton>
-        <NameLabel htmlFor="artistName">이벤트 타입을 입력해 주세요.</NameLabel>
+        <NameLabel htmlFor="artistName">
+          아티스트 타입을 입력해 주세요.
+        </NameLabel>
         <TypeWrapper>{typeContents}</TypeWrapper>
         <CategoryInput
           type="text"
           id="artistName"
-          value={categoryName}
-          onChange={onChangeCategoryName}
+          value={typeName}
+          onChange={onChangeTypeName}
           placeholder="직접 입력"
         />
-        <SubmitButton type="button" onClick={onClickAddCategoryBtn}>
+        <SubmitButton type="button" onClick={onClickAddTypeBtn}>
           완료
         </SubmitButton>
       </CommonModal>
@@ -88,4 +91,4 @@ const AddCategoryModal = () => {
   );
 };
 
-export default AddCategoryModal;
+export default AddArtistTypeModal;

--- a/src/components/modals/AddEventCategoryModal.tsx
+++ b/src/components/modals/AddEventCategoryModal.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+
+import closeIcon from '../../assets/icons/close.svg';
+import {
+  useGetEventCategoryQuery,
+  useAddEventCategoryMutation,
+} from '../../redux/eventCategoryType';
+import { toggleCategory } from '../../redux/manageModalSlice';
+
+import {
+  ModalTitle,
+  ModalCloseButton,
+  CategoryInput,
+  NameLabel,
+  SubmitButton,
+  TypeWrapper,
+} from './AddEventCategoryModalStyle';
+import CommonModal from './CommonModal';
+import { ModalPortal } from './CommonModal';
+import TypeButton from './components/TypeButton';
+
+type categoryType = {
+  id: number;
+  category: string;
+};
+const AddCategoryModal = () => {
+  const [categoryName, setCategoryName] = useState('');
+  const [categoryContents, setCategoryContents] = useState<categoryType[]>([]);
+  const dispatch = useDispatch();
+  const { data: eventCategories } = useGetEventCategoryQuery();
+  const [addNewCategory] = useAddEventCategoryMutation();
+  const onHideModal = () => {
+    dispatch(toggleCategory());
+  };
+
+  const onChangeCategoryName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCategoryName(e.target.value);
+  };
+
+  const onClickAddGroupBtn = async () => {
+    sendCategoryInfo();
+  };
+
+  const sendCategoryInfo = async () => {
+    try {
+      await addNewCategory(categoryName);
+      onHideModal();
+    } catch (error) {
+      console.error(error);
+      alert('앗, 제대로 저장되지 않았어요 다시 시도해주세요');
+    }
+  };
+
+  useEffect(() => {
+    if (eventCategories) setCategoryContents(eventCategories);
+  }, [eventCategories]);
+
+  let typeContents;
+  if (categoryContents.length > 0) {
+    typeContents = categoryContents.map((content) => (
+      <TypeButton
+        key={content.id}
+        data={content}
+        text={content.category}
+        selected={true}
+      />
+    ));
+  }
+
+  return (
+    <ModalPortal>
+      <CommonModal className="addGroupModal" onClick={onHideModal}>
+        <ModalTitle>카테고리 등록하기</ModalTitle>
+        <ModalCloseButton type="button" onClick={onHideModal}>
+          <img src={closeIcon} />
+        </ModalCloseButton>
+        <NameLabel htmlFor="artistName">이벤트 타입을 입력해 주세요.</NameLabel>
+        <TypeWrapper>{typeContents}</TypeWrapper>
+        <CategoryInput
+          type="text"
+          id="artistName"
+          value={categoryName}
+          onChange={onChangeCategoryName}
+          placeholder="직접 입력"
+        />
+        <SubmitButton type="button" onClick={onClickAddGroupBtn}>
+          완료
+        </SubmitButton>
+      </CommonModal>
+    </ModalPortal>
+  );
+};
+
+export default AddCategoryModal;

--- a/src/components/modals/AddEventCategoryModalStyle.tsx
+++ b/src/components/modals/AddEventCategoryModalStyle.tsx
@@ -1,14 +1,8 @@
 import styled from 'styled-components';
 
-import SortDropdown from '../SortButton';
-
-type imageType = {
-  previewimage: string;
-};
-
 export const ModalTitle = styled.h4`
   padding: 13px 58px;
-  margin: 24px 0 22px;
+  margin: 24px 0 24.5px;
   background-color: #fcf9a4;
   border-radius: 73px;
   border: 2.937px solid var(--line-black);
@@ -23,49 +17,13 @@ export const ModalCloseButton = styled.button`
   right: 17px;
 `;
 
-export const TypeTitle = styled.span`
-  font-size: 24px;
-  font-weight: 700;
-`;
-
 export const TypeWrapper = styled.div`
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
   gap: 15px;
   width: 70%;
-  margin: 10px 0 32px;
-`;
-
-export const ImagePreview = styled.label<imageType>`
-  display: block;
-  position: relative;
-  width: 232px;
-  height: 232px;
-  border: 2px solid var(--line-black);
-  border-radius: 30px;
-  text-align: center;
-  cursor: pointer;
-  ${(props) =>
-    props.previewimage
-      ? `
-      background-image: url(${props.previewimage});
-      background-size: cover;
-      background-position: center center;
-      `
-      : `
-      background-color: var(--line-grey2);
-      `}
-  & > img {
-    position: relative;
-    top: 50%;
-    transform: translateY(-50%);
-  }
-`;
-
-export const GroupSortDropdown = styled(SortDropdown)`
-  position: relative;
-  right: 0;
+  margin: 10px 0 14px;
 `;
 
 export const StyledInput = styled.input`
@@ -91,10 +49,11 @@ export const NameLabel = styled.label`
   margin: 10px 20px;
 `;
 
-export const NameInput = styled.input`
-  width: 360px;
+export const CategoryInput = styled.input`
+  width: 608px;
   height: 58px;
   padding: 20px;
+  margin-bottom: 31px;
   font-size: 20px;
   font-weight: 400;
   background-color: #f8f8fa;

--- a/src/components/modals/AddGroupModal.tsx
+++ b/src/components/modals/AddGroupModal.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { styled } from 'styled-components';
 
 import closeIcon from '../../assets/icons/close.svg';
 import photoIcon from '../../assets/icons/photo.svg';
@@ -8,12 +7,18 @@ import { useAddArtistsMutation } from '../../redux/artistsSlice';
 import { useAddImageMutation } from '../../redux/imageSlice';
 import { toggleGroup } from '../../redux/manageModalSlice';
 
+import {
+  ModalTitle,
+  ModalCloseButton,
+  ImageNameWrapper,
+  ImagePreview,
+  StyledInput,
+  NameInput,
+  NameLabel,
+  SubmitButton,
+} from './AddGroupModalStyle';
 import CommonModal from './CommonModal';
 import { ModalPortal } from './CommonModal';
-
-type imageType = {
-  previewimage: string;
-};
 
 const AddGroupModal = () => {
   const [groupImage, setGroupImage] = useState<File>();
@@ -117,94 +122,3 @@ const AddGroupModal = () => {
 };
 
 export default AddGroupModal;
-
-const ModalTitle = styled.h4`
-  width: 300px;
-  padding: 13px 58px;
-  margin: 24px 0 50px;
-  background-color: #fcf9a4;
-  border-radius: 73px;
-  border: 2.937px solid var(--line-black);
-  font-size: 28px;
-  font-weight: 700;
-  text-align: center;
-`;
-
-const ModalCloseButton = styled.button`
-  position: absolute;
-  top: 10px;
-  right: 17px;
-`;
-
-const ImagePreview = styled.label<imageType>`
-  display: block;
-  position: relative;
-  width: 232px;
-  height: 232px;
-  border: 2px solid var(--line-black);
-  border-radius: 30px;
-  text-align: center;
-  cursor: pointer;
-  ${(props) =>
-    props.previewimage
-      ? `
-        background-image: url(${props.previewimage});
-        background-size: cover;
-        background-position: center center;
-        `
-      : `
-        background-color: var(--line-grey2);
-        `}
-  & > img {
-    position: relative;
-    top: 50%;
-    transform: translateY(-50%);
-  }
-`;
-
-const StyledInput = styled.input`
-  position: absolute;
-  clip: rect(0 0 0 0);
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-`;
-
-const ImageNameWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  margin-bottom: 26px;
-`;
-
-const NameLabel = styled.label`
-  display: block;
-  font-size: 24px;
-  font-weight: 700;
-  margin: 10px 20px;
-`;
-const NameInput = styled.input`
-  width: 360px;
-  height: 58px;
-  padding: 20px;
-  font-size: 20px;
-  font-weight: 400;
-  background-color: #f8f8fa;
-  border: 1.4px solid var(--font-black);
-  border-radius: 30px;
-  &::placeholder {
-    font-size: 20px;
-    color: 4e5761;
-  }
-`;
-
-const SubmitButton = styled.button`
-  width: 202px;
-  font-size: 35px;
-  font-weight: 700;
-  padding: 16px;
-  border: 3px solid var(--line-black);
-  border-radius: 73px;
-  background-color: #defcf9;
-`;

--- a/src/components/modals/AddGroupModal.tsx
+++ b/src/components/modals/AddGroupModal.tsx
@@ -64,15 +64,13 @@ const AddGroupModal = () => {
   };
 
   const sendGroupInfo = async (imageData: any) => {
-    console.log(imageData);
     const groupData = {
       artistTypeId: 1,
       name: groupName,
       image: imageData,
     };
     try {
-      const response = await addNewGroup(groupData);
-      console.log(response);
+      await addNewGroup(groupData);
       onHideModal();
     } catch (error) {
       console.error(error);

--- a/src/components/modals/AddGroupModalStyle.tsx
+++ b/src/components/modals/AddGroupModalStyle.tsx
@@ -80,9 +80,10 @@ export const NameInput = styled.input`
   background-color: #f8f8fa;
   border: 1.4px solid var(--font-black);
   border-radius: 30px;
+  box-shadow: 7px 5px 0px 0px rgb(0, 0, 0, 0.3);
   &::placeholder {
     font-size: 20px;
-    color: 4e5761;
+    color: #8f9196;
   }
 `;
 
@@ -94,4 +95,5 @@ export const SubmitButton = styled.button`
   border: 3px solid var(--line-black);
   border-radius: 73px;
   background-color: #defcf9;
+  box-shadow: 6px 4px 0px 0px rgb(0, 0, 0, 0.3);
 `;

--- a/src/components/modals/AddGroupModalStyle.tsx
+++ b/src/components/modals/AddGroupModalStyle.tsx
@@ -1,0 +1,97 @@
+import styled from 'styled-components';
+
+type imageType = {
+  previewimage: string;
+};
+
+export const ModalTitle = styled.h4`
+  width: 300px;
+  padding: 13px 58px;
+  margin: 24px 0 50px;
+  background-color: #fcf9a4;
+  border-radius: 73px;
+  border: 2.937px solid var(--line-black);
+  font-size: 28px;
+  font-weight: 700;
+  text-align: center;
+`;
+
+export const ModalCloseButton = styled.button`
+  position: absolute;
+  top: 10px;
+  right: 17px;
+`;
+
+export const ImagePreview = styled.label<imageType>`
+  display: block;
+  position: relative;
+  width: 232px;
+  height: 232px;
+  border: 2px solid var(--line-black);
+  border-radius: 30px;
+  text-align: center;
+  cursor: pointer;
+  ${(props) =>
+    props.previewimage
+      ? `
+        background-image: url(${props.previewimage});
+        background-size: cover;
+        background-position: center center;
+        `
+      : `
+        background-color: var(--line-grey2);
+        `}
+  & > img {
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+`;
+
+export const StyledInput = styled.input`
+  position: absolute;
+  clip: rect(0 0 0 0);
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+`;
+
+export const ImageNameWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 26px;
+`;
+
+export const NameLabel = styled.label`
+  display: block;
+  font-size: 24px;
+  font-weight: 700;
+  margin: 10px 20px;
+`;
+
+export const NameInput = styled.input`
+  width: 360px;
+  height: 58px;
+  padding: 20px;
+  font-size: 20px;
+  font-weight: 400;
+  background-color: #f8f8fa;
+  border: 1.4px solid var(--font-black);
+  border-radius: 30px;
+  &::placeholder {
+    font-size: 20px;
+    color: 4e5761;
+  }
+`;
+
+export const SubmitButton = styled.button`
+  width: 202px;
+  font-size: 35px;
+  font-weight: 700;
+  padding: 16px;
+  border: 3px solid var(--line-black);
+  border-radius: 73px;
+  background-color: #defcf9;
+`;

--- a/src/components/modals/components/TypeButton.tsx
+++ b/src/components/modals/components/TypeButton.tsx
@@ -1,0 +1,68 @@
+import styled from 'styled-components';
+
+import { artistType } from '../../../types/artistsType';
+
+type propsType = {
+  data: artistType;
+  selected: boolean;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+type groupType = {
+  type: string;
+  selected: boolean;
+};
+
+const TypeButton = ({ data, onChange, selected }: propsType) => {
+  return (
+    <>
+      <TypeLabel
+        htmlFor={data.id.toString()}
+        type={data.type}
+        selected={selected}
+      >
+        {data.type}
+      </TypeLabel>
+      <StyledInput
+        type="radio"
+        id={data.id.toString()}
+        name="artistType"
+        value={data.id.toString()}
+        onChange={onChange}
+      />
+    </>
+  );
+};
+
+export default TypeButton;
+
+const TypeLabel = styled.label<groupType>`
+  width: 130px;
+  font-size: 20px;
+  font-weight: 400;
+  text-align: center;
+  padding: 10px 20px;
+  border-radius: 30px;
+  box-shadow: 4.4px 4.4px 0px 0px rgba(0, 0, 0, 0.25);
+  cursor: pointer;
+  ${(props) =>
+    props.selected
+      ? `
+      background-color: #f8f8fa;
+      border: 2px solid var(--line-black);
+     `
+      : `
+      color: #8F9196;
+      border: 2.056px solid #8B8E97;
+      background: #EDEDED;
+      `}
+`;
+
+const StyledInput = styled.input`
+  position: absolute;
+  clip: rect(0 0 0 0);
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+`;

--- a/src/components/modals/components/TypeButton.tsx
+++ b/src/components/modals/components/TypeButton.tsx
@@ -1,19 +1,18 @@
 import styled from 'styled-components';
 
-import { artistType } from '../../../types/artistsType';
-
 type propsType = {
-  data: artistType;
+  data: { id: number; type?: string; category?: string };
+  text: string;
   selected: boolean;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
 type groupType = {
-  type: string;
+  type?: string;
   selected: boolean;
 };
 
-const TypeButton = ({ data, onChange, selected }: propsType) => {
+const TypeButton = ({ data, text, onChange, selected }: propsType) => {
   return (
     <>
       <TypeLabel
@@ -21,7 +20,7 @@ const TypeButton = ({ data, onChange, selected }: propsType) => {
         type={data.type}
         selected={selected}
       >
-        {data.type}
+        {text}
       </TypeLabel>
       <StyledInput
         type="radio"
@@ -43,13 +42,13 @@ const TypeLabel = styled.label<groupType>`
   text-align: center;
   padding: 10px 20px;
   border-radius: 30px;
-  box-shadow: 4.4px 4.4px 0px 0px rgba(0, 0, 0, 0.25);
   cursor: pointer;
   ${(props) =>
     props.selected
       ? `
-      background-color: #f8f8fa;
-      border: 2px solid var(--line-black);
+    background-color: #f8f8fa;
+    border: 2px solid var(--line-black);
+    box-shadow: 4.4px 4.4px 0px 0px rgba(0, 0, 0, 0.25);
      `
       : `
       color: #8F9196;

--- a/src/layout/GeneralLayout.tsx
+++ b/src/layout/GeneralLayout.tsx
@@ -4,7 +4,9 @@ import { styled } from 'styled-components';
 import Billboard from '../components/Billboard';
 import Header from '../components/Header';
 import AddArtistModal from '../components/modals/AddArtistModal';
+import AddCategoryModal from '../components/modals/AddEventCategoryModal';
 import AddGroupModal from '../components/modals/AddGroupModal';
+import { selectCategoryModalState } from '../redux/manageModalSlice';
 import { selectGroupModalState } from '../redux/manageModalSlice';
 import { selectArtistModalState } from '../redux/manageModalSlice';
 
@@ -20,12 +22,14 @@ const PageWrapper = styled.section`
 const GeneralLayout: React.FC<GeneralLayoutProps> = ({ children }) => {
   const groupModalState = useSelector(selectGroupModalState);
   const artistModalState = useSelector(selectArtistModalState);
+  const categoryModalState = useSelector(selectCategoryModalState);
 
   return (
     <PageWrapper>
       <Billboard />
       {groupModalState && <AddGroupModal />}
       {artistModalState && <AddArtistModal />}
+      {categoryModalState && <AddCategoryModal />}
       <Header />
       {children}
     </PageWrapper>

--- a/src/layout/GeneralLayout.tsx
+++ b/src/layout/GeneralLayout.tsx
@@ -4,11 +4,15 @@ import { styled } from 'styled-components';
 import Billboard from '../components/Billboard';
 import Header from '../components/Header';
 import AddArtistModal from '../components/modals/AddArtistModal';
+import AddArtistTypeModal from '../components/modals/AddArtistTypeModal';
 import AddCategoryModal from '../components/modals/AddEventCategoryModal';
 import AddGroupModal from '../components/modals/AddGroupModal';
-import { selectCategoryModalState } from '../redux/manageModalSlice';
-import { selectGroupModalState } from '../redux/manageModalSlice';
-import { selectArtistModalState } from '../redux/manageModalSlice';
+import {
+  selectCategoryModalState,
+  selectGroupModalState,
+  selectArtistTypeModalState,
+  selectArtistModalState,
+} from '../redux/manageModalSlice';
 
 interface GeneralLayoutProps {
   children: React.ReactNode;
@@ -22,6 +26,7 @@ const PageWrapper = styled.section`
 const GeneralLayout: React.FC<GeneralLayoutProps> = ({ children }) => {
   const groupModalState = useSelector(selectGroupModalState);
   const artistModalState = useSelector(selectArtistModalState);
+  const artistTypeModalState = useSelector(selectArtistTypeModalState);
   const categoryModalState = useSelector(selectCategoryModalState);
 
   return (
@@ -29,6 +34,7 @@ const GeneralLayout: React.FC<GeneralLayoutProps> = ({ children }) => {
       <Billboard />
       {groupModalState && <AddGroupModal />}
       {artistModalState && <AddArtistModal />}
+      {artistTypeModalState && <AddArtistTypeModal />}
       {categoryModalState && <AddCategoryModal />}
       <Header />
       {children}

--- a/src/pages/ManagePage/ArtistListItem.tsx
+++ b/src/pages/ManagePage/ArtistListItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import deleteIcon from '../../assets/icons/delete.svg';
 import editIcon from '../../assets/icons/edit.svg';
+import { useDeleteArtistsMutation } from '../../redux/artistsSlice';
 import { ArtistContent } from '../../types/artistsType';
 
 import {
@@ -19,6 +20,20 @@ const ArtistListItem = ({ data }: { data: ArtistContent }) => {
     'https://images.unsplash.com/photo-1567880905822-56f8e06fe630?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=735&q=80';
   const artistImage = data.image !== '/images/null' ? data.image : testImg;
 
+  const [deleteArtist] = useDeleteArtistsMutation();
+  const onClickDeleteBtn = async () => {
+    console.log(data.id);
+    if (!window.confirm(`아티스트 "${data.name}"(을)를 삭제하시겠습니까?`)) {
+      return;
+    }
+    try {
+      await deleteArtist(data.id);
+      alert('성공적으로 삭제되었습니다!');
+      //화면에서 지워져야 하는데!
+    } catch (error) {
+      console.log(error);
+    }
+  };
   return (
     <ListItem>
       <ListItemTitle>
@@ -26,7 +41,7 @@ const ArtistListItem = ({ data }: { data: ArtistContent }) => {
         <CommonButton type="button">
           <img src={editIcon} />
         </CommonButton>
-        <CommonButton type="button">
+        <CommonButton type="button" onClick={onClickDeleteBtn}>
           <img src={deleteIcon} />
         </CommonButton>
       </ListItemTitle>

--- a/src/pages/ManagePage/Manage.tsx
+++ b/src/pages/ManagePage/Manage.tsx
@@ -18,6 +18,8 @@ import {
   ArtistListSection,
 } from './ManageStyle';
 
+const loadedData = new Map();
+
 const Manage = () => {
   const [artistsArray, setArtistsArray] = useState<ArtistContent[]>([]);
   const [artistlistPage, setArtistListPage] = useState(0);
@@ -44,11 +46,19 @@ const Manage = () => {
 
   useEffect(() => {
     if (artistData) {
-      setArtistsArray((prev) => [...prev, ...artistData.content]);
+      artistData.content.forEach((item) => {
+        const uniqueId = item.id;
+
+        if (!loadedData.has(uniqueId)) {
+          loadedData.set(uniqueId, item);
+        }
+      });
+      const filteredArtistData = Array.from(loadedData.values());
+      setArtistsArray(filteredArtistData);
     }
   }, [artistData]);
 
-  const isLast = artistData?.last ?? true;
+  const isLast = artistData?.isLast ?? true;
 
   let content;
 

--- a/src/redux/apiSlice.ts
+++ b/src/redux/apiSlice.ts
@@ -12,6 +12,6 @@ export const apiSlice = createApi({
       'Accept': 'application/json',
     },
   }),
-  tagTypes: ['ArtistType', 'Artists', 'Images'],
+  tagTypes: ['ArtistType', 'Artists', 'Images', 'EventCategory'],
   endpoints: () => ({}),
 });

--- a/src/redux/artistsSlice.ts
+++ b/src/redux/artistsSlice.ts
@@ -3,7 +3,8 @@ import { ArtistValue, ArtistsData } from '../types/artistsType';
 import { apiSlice } from './apiSlice';
 
 const accessToken = window.localStorage.getItem('admin');
-type transformedResponse = {
+
+export type transformedResponse = {
   isLast: boolean;
   content: [
     {
@@ -19,6 +20,7 @@ type transformedResponse = {
     }
   ];
 };
+
 export const artistsApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
     getArtists: builder.query<
@@ -26,8 +28,8 @@ export const artistsApiSlice = apiSlice.injectEndpoints({
       {
         artistTypeId?: string;
         artistName?: string | undefined;
-        pageNumber: string;
-        pageSize: string;
+        pageNumber?: string;
+        pageSize?: string;
       }
     >({
       query: (params) => {
@@ -92,6 +94,40 @@ export const artistsApiSlice = apiSlice.injectEndpoints({
         },
       }),
       invalidatesTags: ['Artists'],
+      async onQueryStarted({ artistId }, { dispatch, queryFulfilled }) {
+        // for (const { endpointName } of apiSlice.util.selectInvalidatedBy(
+        //   getState(),
+        //   [{ type: 'Artists', id: artistId }]
+        // )) {
+        //   if (endpointName !== 'getArtists') continue;
+        //   dispatch(
+        //     artistsApiSlice.util.updateQueryData('getArtists', {}, (draft) => {
+        //       const deleteItemIndex = draft.content.findIndex(
+        //         (data) => data.id === artistId
+        //       );
+        //       draft.content.splice(deleteItemIndex, 1);
+        //     })
+        //   );
+        // }
+        const patchResult = dispatch(
+          artistsApiSlice.util.updateQueryData(
+            'getArtists',
+            { pageNumber: '2', pageSize: '20' },
+            (draft) => {
+              const deleteItemIndex = draft.content.findIndex(
+                (data) => data.id === artistId
+              );
+              draft.content.splice(deleteItemIndex, 1);
+            }
+          )
+        );
+        try {
+          const response = await queryFulfilled;
+          console.log(response);
+        } catch (error) {
+          patchResult.undo();
+        }
+      },
     }),
   }),
 });

--- a/src/redux/artistsSlice.ts
+++ b/src/redux/artistsSlice.ts
@@ -3,11 +3,26 @@ import { ArtistValue, ArtistsData } from '../types/artistsType';
 import { apiSlice } from './apiSlice';
 
 const accessToken = window.localStorage.getItem('admin');
-
+type transformedResponse = {
+  isLast: boolean;
+  content: [
+    {
+      id: number;
+      groupId: number | null;
+      groupName: string | null;
+      name: string;
+      image: string;
+      artistType: {
+        id: number;
+        type: string;
+      };
+    }
+  ];
+};
 export const artistsApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
     getArtists: builder.query<
-      ArtistsData,
+      transformedResponse,
       {
         artistTypeId?: string;
         artistName?: string | undefined;
@@ -25,6 +40,14 @@ export const artistsApiSlice = apiSlice.injectEndpoints({
           url: url + '?' + queryString,
           method: 'GET',
         };
+      },
+      transformResponse: (response: ArtistsData) => {
+        const content = response.content;
+        const isLast = response.last;
+        return { content, isLast };
+      },
+      serializeQueryArgs: ({ queryArgs, endpointName }) => {
+        return endpointName + queryArgs.artistTypeId + queryArgs.pageNumber;
       },
       providesTags: ['Artists'],
     }),

--- a/src/redux/eventCategoryType.ts
+++ b/src/redux/eventCategoryType.ts
@@ -1,0 +1,31 @@
+import { apiSlice } from './apiSlice';
+
+type categoryType = {
+  id: number;
+  category: string;
+};
+
+const accessToken = window.localStorage.getItem('admin');
+
+export const eventCategoryApiSlice = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    getEventCategory: builder.query<categoryType[], void>({
+      query: () => 'events/categories',
+      providesTags: ['EventCategory'],
+    }),
+    addEventCategory: builder.mutation({
+      query: (category: string) => ({
+        url: 'events/categories',
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: { category },
+      }),
+      invalidatesTags: ['EventCategory'],
+    }),
+  }),
+});
+
+export const { useGetEventCategoryQuery, useAddEventCategoryMutation } =
+  eventCategoryApiSlice;

--- a/src/redux/manageModalSlice.ts
+++ b/src/redux/manageModalSlice.ts
@@ -7,6 +7,7 @@ export const manageModalSlice = createSlice({
   initialState: {
     group: false,
     artist: false,
+    artistType: false,
     category: false,
   },
   reducers: {
@@ -16,13 +17,16 @@ export const manageModalSlice = createSlice({
     toggleArtist: (state) => {
       state.artist = !state.artist;
     },
+    toggleArtistType: (state) => {
+      state.artistType = !state.artistType;
+    },
     toggleCategory: (state) => {
       state.category = !state.category;
     },
   },
 });
 
-export const { toggleArtist, toggleCategory, toggleGroup } =
+export const { toggleArtist, toggleCategory, toggleArtistType, toggleGroup } =
   manageModalSlice.actions;
 
 export default manageModalSlice.reducer;
@@ -32,6 +36,9 @@ export const selectGroupModalState = (state: RootState) =>
 
 export const selectArtistModalState = (state: RootState) =>
   state.manageModal.artist;
+
+export const selectArtistTypeModalState = (state: RootState) =>
+  state.manageModal.artistType;
 
 export const selectCategoryModalState = (state: RootState) =>
   state.manageModal.category;


### PR DESCRIPTION
## Describe your changes

- 그룹/아티스트 등록 직후 중복된 데이터가 보여지는 버그 해결 #145 
- 이벤트 카테고리 등록 기능
- 아티스트 타입 등록 기능
- 아티스트 삭제 기능 #147 

## To-do before merge
- 현재 아티스트를 삭제했을 때 바로 UI에 반영되지 않고 새로고침을 해야지만 반영이 됩니다. invalidatesTags 설정이 되어 있는데도 바로 불러오지는 않네요.. 그래서 Optimistic Updates를 하려고 찾아보니 rtk query에 onQueryStarted, updateQueryData를 사용하는 방법이 있더라구요. 그래서 계속 시도를 해보았지만 해결할 수 없었습니다... 버그 이슈에 등록해두고 방법을 계속 찾아보겠습니다.🫠 
