### PR TITLE
인증 로직 변경

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -78,6 +78,8 @@ const Header: React.FC = ({}) => {
   const dispatch = useDispatch();
   const user = useSelector(selectCurrentUser);
   const [logout] = useLogoutMutation();
+  const baseUrl = process.env.REACT_APP_BASE_URL;
+
   const handleProfileClick = () => {
     if (user) {
       routeTo('/mypage');
@@ -179,7 +181,11 @@ const Header: React.FC = ({}) => {
         </MenuButton>
         <ProfileDropdown>
           <ProfileImg
-            src={defaultImage}
+            src={
+              user?.userProfile && user?.userProfile !== '/images/null'
+                ? `${baseUrl}${user.userProfile}`
+                : defaultImage
+            }
             alt="Profile"
             onClick={handleProfileClick}
           />

--- a/src/pages/SignPage/Signin.tsx
+++ b/src/pages/SignPage/Signin.tsx
@@ -2,7 +2,6 @@ import { FormEvent, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { styled } from 'styled-components';
 
-// import client from '../../api/client';
 import kakaoIcon from '../../assets/kakao-icon.svg';
 import naverIcon from '../../assets/naver-icon.svg';
 import AuthInput from '../../components/AuthInput';
@@ -14,7 +13,7 @@ import {
   useFetchUserMutation,
   useLoginMutation,
 } from '../../redux/auth/authApiSlice';
-import { setCredentials } from '../../redux/auth/authSlice';
+import { setCredentials, setUser } from '../../redux/auth/authSlice';
 
 import {
   PageTitle,
@@ -46,40 +45,12 @@ const Signin = () => {
   const [fetchUser] = useFetchUserMutation();
   const dispatch = useDispatch();
 
-  // const getImage = async () => {
-  //   try {
-  //     const imageRes = await client.get(
-  //       '/images/0b4ca0d6-89e6-4094-a170-59fcd5fcfbf3.jpg'
-  //     );
-  //     const imageData = imageRes.data;
-  //     console.log(imageData);
-
-  //     return imageData;
-  //   } catch (error) {
-  //     console.error('Error fetching image data:', error);
-  //     return null;
-  //   }
-  // };
-
   const getUser = async () => {
-    try {
-      const res = await fetchUser({});
-      if ('userProfile' in res) {
-        // TODO: 이미지 값 받아오기
-        // const userProfile = await getImage();
-        // if (userProfile !== null) {
-        //   const updatedRes = {
-        //     ...res,
-        //     userProfile: userProfile,
-        //   };
-        //   console.log(updatedRes.userProfile); // 이미지 데이터 확인
-        //   return updatedRes;
-        // }
-      }
-      return res;
-    } catch (error) {
-      console.error(error);
+    const userData = await fetchUser({});
+    if (userData && !('error' in userData)) {
+      return userData;
     }
+    return;
   };
 
   const handleSignin = async (e: FormEvent<HTMLFormElement>) => {
@@ -91,20 +62,10 @@ const Signin = () => {
           password: password.value,
         }).unwrap();
 
-        dispatch(
-          setCredentials({
-            accessToken: userData.authorizationHeader,
-            user: null,
-          })
-        );
+        dispatch(setCredentials(userData.authorizationHeader));
 
         const user = await getUser();
-        dispatch(
-          setCredentials({
-            accessToken: userData.authorizationHeader,
-            user: user,
-          })
-        );
+        dispatch(setUser(user?.data));
 
         routeTo('/');
       } catch (error) {

--- a/src/redux/apiSlice.ts
+++ b/src/redux/apiSlice.ts
@@ -8,10 +8,10 @@ import {
 import { logOut, setCredentials } from './auth/authSlice';
 import { RootState } from './store';
 
-// const baseUrl = process.env.REACT_APP_BASE_URL;
+const baseUrl = process.env.REACT_APP_BASE_URL;
 
 const baseQuery = fetchBaseQuery({
-  // baseUrl: baseUrl,
+  baseUrl: baseUrl,
   credentials: 'include',
   mode: 'cors',
   prepareHeaders: (headers, { getState }) => {

--- a/src/redux/auth/authSlice.ts
+++ b/src/redux/auth/authSlice.ts
@@ -23,9 +23,12 @@ const authSlice = createSlice({
   initialState,
   reducers: {
     setCredentials: (state, action) => {
-      const { user, accessToken } = action.payload;
-      state.user = user;
+      const accessToken = action.payload;
       state.token = accessToken;
+    },
+    setUser: (state, action) => {
+      const user = action.payload;
+      state.user = user;
     },
     logOut: (state, _action) => {
       state.user = null;
@@ -38,7 +41,7 @@ const authSlice = createSlice({
   },
 });
 
-export const { setCredentials, logOut, FetchUser } = authSlice.actions;
+export const { setCredentials, setUser, logOut, FetchUser } = authSlice.actions;
 
 export default authSlice.reducer;
 


### PR DESCRIPTION
## Describe your changes

인증 로직 변경하였습니다.

- 토큰, 유저 저장 reducer 분리
- baseURL 주석 풀기
- 하는 김에 헤더 컴포넌트에 프로필 이미지 유무에 따라 src 값 주도록 수정하였습니다. 기존엔 그냥 기본이미지로 넣어뒀었습니다.
- 로그인 문제는 백엔드 분과 이야기 나눠 헤더의 authorization 접근 가능하도록 해결하였습니다
- 리프레쉬 토큰이 브라우저에 자동으로 저장되지 않는 현상은 아직 더 찾아보는 중 입니다.
