### PR TITLE
browser-image-compression 설치 및 이미지 압축 로직 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@uiw/color-convert": "^1.3.3",
         "@uiw/react-color-wheel": "^1.3.3",
         "axios": "^1.4.0",
+        "browser-image-compression": "^2.0.2",
         "dotenv": "^16.3.1",
         "react": "^18.2.0",
         "react-copy-to-clipboard": "^5.1.0",
@@ -5036,6 +5037,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browser-process-hrtime": {
@@ -14941,6 +14950,11 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@uiw/color-convert": "^1.3.3",
     "@uiw/react-color-wheel": "^1.3.3",
     "axios": "^1.4.0",
+    "browser-image-compression": "^2.0.2",
     "dotenv": "^16.3.1",
     "react": "^18.2.0",
     "react-copy-to-clipboard": "^5.1.0",

--- a/src/components/modals/ArtistModal.tsx
+++ b/src/components/modals/ArtistModal.tsx
@@ -64,7 +64,7 @@ const ArtistModal = ({ type }: ModalProps) => {
   const [SortModal, setSortModal] = useState(false);
   const [groupPageNumber, _] = useState(0);
   const [sortOption, setSortOption] = useState<sortOptionsType[]>([]);
-  const [isImgSaving, setIsImgSaving] = useState(false);
+  const [isImgCompressing, setIsImgCompressing] = useState(false);
   const pageSize = '20';
   const [addNewImage] = useAddImageMutation({});
   const { data: artistTypeData } = useGetArtistsTypeQuery();
@@ -131,12 +131,12 @@ const ArtistModal = ({ type }: ModalProps) => {
       const imgFile = e.target.files[0];
       imgFile && setPreviewImage(URL.createObjectURL(imgFile));
       try {
-        setIsImgSaving(true);
+        setIsImgCompressing(true);
         const compressedFile = await imageCompression(imgFile, {
           maxSizeMB: 0.5,
         });
         setArtistImage(compressedFile);
-        setIsImgSaving(false);
+        setIsImgCompressing(false);
       } catch (error) {
         console.error(error);
       }
@@ -145,7 +145,7 @@ const ArtistModal = ({ type }: ModalProps) => {
 
   //** 리팩토링 필수 * /
   const onClickAddArtistBtn = async () => {
-    if (isImgSaving) {
+    if (isImgCompressing) {
       alert('사진 처리 중입니다. 잠시 후 다시 시도해주세요.');
       return;
     }

--- a/src/components/modals/ArtistModal.tsx
+++ b/src/components/modals/ArtistModal.tsx
@@ -133,7 +133,8 @@ const ArtistModal = ({ type }: ModalProps) => {
       try {
         setIsImgCompressing(true);
         const compressedFile = await imageCompression(imgFile, {
-          maxSizeMB: 0.5,
+          maxSizeMB: 0.2,
+          maxIteration: 30,
         });
         setArtistImage(compressedFile);
         setIsImgCompressing(false);

--- a/src/components/modals/ArtistModal.tsx
+++ b/src/components/modals/ArtistModal.tsx
@@ -137,7 +137,6 @@ const ArtistModal = ({ type }: ModalProps) => {
         });
         setArtistImage(compressedFile);
         setIsImgSaving(false);
-
       } catch (error) {
         console.error(error);
       }
@@ -164,7 +163,7 @@ const ArtistModal = ({ type }: ModalProps) => {
         const response = await addNewImage({
           imageFile: formData,
         });
-        
+
         if ('error' in response) {
           return;
         }

--- a/src/components/modals/GroupModal.tsx
+++ b/src/components/modals/GroupModal.tsx
@@ -37,7 +37,7 @@ const GroupModal = ({ type }: ModalType) => {
   const [groupImage, setGroupImage] = useState<File>();
   const [previewImage, setPreviewImage] = useState<string>('');
   const [groupName, setGroupName] = useState('');
-  const [isImgSaving, setIsImgSaving] = useState(false);
+  const [isImgCompressing, setIsImgCompressing] = useState(false);
   const [addNewImage] = useAddImageMutation({});
   const [addNewGroup] = useAddArtistsMutation();
   const [editGroup] = useEditArtistsMutation();
@@ -72,12 +72,12 @@ const GroupModal = ({ type }: ModalType) => {
       const imgFile = e.target.files[0];
       imgFile && setPreviewImage(URL.createObjectURL(imgFile));
       try {
-        setIsImgSaving(true);
+        setIsImgCompressing(true);
         const compressedFile = await imageCompression(imgFile, {
           maxSizeMB: 0.5,
         });
         setGroupImage(compressedFile);
-        setIsImgSaving(false);
+        setIsImgCompressing(false);
       } catch (error) {
         console.error(error);
       }
@@ -86,7 +86,7 @@ const GroupModal = ({ type }: ModalType) => {
 
   //** 리팩토링 필수 */
   const onClickAddGroupBtn = async () => {
-    if (isImgSaving) {
+    if (isImgCompressing) {
       alert('사진 처리 중입니다. 잠시 후 다시 시도해주세요.');
       return;
     }

--- a/src/components/modals/GroupModal.tsx
+++ b/src/components/modals/GroupModal.tsx
@@ -1,3 +1,4 @@
+import imageCompression from 'browser-image-compression';
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -36,6 +37,7 @@ const GroupModal = ({ type }: ModalType) => {
   const [groupImage, setGroupImage] = useState<File>();
   const [previewImage, setPreviewImage] = useState<string>('');
   const [groupName, setGroupName] = useState('');
+  const [isImgSaving, setIsImgSaving] = useState(false);
   const [addNewImage] = useAddImageMutation({});
   const [addNewGroup] = useAddArtistsMutation();
   const [editGroup] = useEditArtistsMutation();
@@ -65,22 +67,29 @@ const GroupModal = ({ type }: ModalType) => {
     setGroupName(e.target.value);
   };
 
-  const onChangeGroupImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onChangeGroupImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
       const imgFile = e.target.files[0];
-      //파일 size 확인
-      if (imgFile.size > 1024 ** 2) {
-        alert('앗! 이미지가 너무 커요. 1MB 이하의 사진만 업로드 가능합니다.');
-        return;
+      imgFile && setPreviewImage(URL.createObjectURL(imgFile));
+      try {
+        setIsImgSaving(true);
+        const compressedFile = await imageCompression(imgFile, {
+          maxSizeMB: 0.5,
+        });
+        setGroupImage(compressedFile);
+        setIsImgSaving(false);
+      } catch (error) {
+        console.error(error);
       }
-      setGroupImage(imgFile);
-      setPreviewImage(URL.createObjectURL(imgFile));
     }
   };
 
   //** 리팩토링 필수 */
   const onClickAddGroupBtn = async () => {
-    const formData = new FormData();
+    if (isImgSaving) {
+      alert('사진 처리 중입니다. 잠시 후 다시 시도해주세요.');
+      return;
+    }
 
     if (groupImage === undefined) {
       if (previewImage === undefined) {
@@ -88,7 +97,8 @@ const GroupModal = ({ type }: ModalType) => {
       }
     }
 
-    if (groupImage instanceof File) {
+    if (groupImage) {
+      const formData = new FormData();
       formData.append('file', groupImage);
       try {
         const response = await addNewImage({

--- a/src/components/modals/GroupModal.tsx
+++ b/src/components/modals/GroupModal.tsx
@@ -74,7 +74,8 @@ const GroupModal = ({ type }: ModalType) => {
       try {
         setIsImgCompressing(true);
         const compressedFile = await imageCompression(imgFile, {
-          maxSizeMB: 0.5,
+          maxSizeMB: 0.2,
+          maxIteration: 30,
         });
         setGroupImage(compressedFile);
         setIsImgCompressing(false);

--- a/src/pages/MyPage/components/EditProfile.tsx
+++ b/src/pages/MyPage/components/EditProfile.tsx
@@ -60,7 +60,8 @@ const EditProfile = () => {
       try {
         setIsImgCompressing(true);
         const compressedFile = await imageCompression(imgFile, {
-          maxSizeMB: 0.5,
+          maxSizeMB: 0.2,
+          maxIteration: 30,
         });
         setUserImage(compressedFile);
         setIsImgCompressing(false);

--- a/src/pages/MyPage/components/EditProfile.tsx
+++ b/src/pages/MyPage/components/EditProfile.tsx
@@ -32,7 +32,7 @@ const EditProfile = () => {
   const [savedImagefile, setSavedImagefile] = useState<string>(''); // 저장된 이미지의 filename
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
-  const [isImgSaving, setIsImgSaving] = useState(false);
+  const [isImgCompressing, setIsImgCompressing] = useState(false);
   const { data: userData } = useGetUserInfoQuery();
   const [editUserInfo] = useEditUserInfoMutation();
   const [addNewImage] = useAddImageMutation();
@@ -58,12 +58,12 @@ const EditProfile = () => {
       const imgFile = e.target.files[0];
       imgFile && setPreviewImage(URL.createObjectURL(imgFile));
       try {
-        setIsImgSaving(true);
+        setIsImgCompressing(true);
         const compressedFile = await imageCompression(imgFile, {
           maxSizeMB: 0.5,
         });
         setUserImage(compressedFile);
-        setIsImgSaving(false);
+        setIsImgCompressing(false);
       } catch (error) {
         console.error(error);
       }
@@ -76,7 +76,7 @@ const EditProfile = () => {
 
   const onClickSubmitBtn = async () => {
     //이미지 압축 중일 떄
-    if (isImgSaving) {
+    if (isImgCompressing) {
       alert('사진처리 중입니다. 잠시후 다시 시도해주세요. ');
       return;
     }


### PR DESCRIPTION
## Describe your changes

- browser-image-compression 설치
- 마이페이지 내 프로필 이미지 수정 시 이미지 압축 로직 추가
- 그룹 등록/수정 모달, 아티스트 등록/수정 모달에 이미지 압축 로직 추가

## To-do before merge
- browser-image-compression 를 새롭게 설치해서 pull 받으시구 npm i 해주셔야 합니다! 예징이님 리뷰등록이랑 이벤트 등록에도 추가해주세요! 간단해서 금방 하실 거 같습니다!
- `imageCompression` 함수를 이용해서 압축하는데, 이게 이미지 용량이 클수록 응답이 오기까지에 시간이 걸리더라구요. 그 응답이 오기 전에 다른 요청을 보내버리면 이미지가 제대로 저장되지 않는 버그가 날 거 같아요. 그래서 `isImgCompressing` 상태 만들어서 압축 완료됐을 때만 다른 요청 보낼 수 있도록 해두었습니다! 

### 추가된 내용
- ~~파일 최대 사이즈는 0.5MB 로 해두었습니다. 서버에서 1MB가 제한이긴 한데 이미지 크기는 작을수록 좋을 거 같아서요. 그래서 임의로 설정해두었습니다. 사실 더 작아도 될 거 같긴 합니다. 찾아보니 0.2로 설정하기도 하고 0.5로 설정하기도 하더라구요?!~~ => 벡엔드분들과 상의 결과 우선 0.2로 설정했습니다!
- 2~40mb 정도되는 큰 이미지로 테스트해봤을 때 압축 후 크기가 원하는 만큼 줄어들지 않고 600kb정도에 계속 머물러있었습니다. 찾아보니 각 iteration마다 압축을 진행하는데 maxIteration의 디폴트값이 10이라 그랬더라구요. 그래서 maxIteration값을 30정도로 설정해두었습니다. https://github.com/Donaldcwl/browser-image-compression/issues/140
