### PR TITLE
헤더, 마이페이지 반응형 작업

### DIFF
--- a/src/components/FixedRating.tsx
+++ b/src/components/FixedRating.tsx
@@ -2,10 +2,11 @@ import { css, styled } from 'styled-components';
 
 import emptyStar from '../assets/star-empty.svg';
 import filledStar from '../assets/star-filled.svg';
+import media from '../utils/mediaQuery';
 
 const Wrapper = styled.div<{
   $marginB?: string;
-  $size?: 'primary' | 'reviewItem';
+  $size?: 'primary' | 'reviewItem' | 'reviewItemMobile';
 }>`
   display: flex;
   align-items: center;
@@ -27,6 +28,10 @@ const reviewItemWrapper = css`
   background-color: #fffcedfa;
   border: 2px solid #1e232c;
   border-radius: 20px;
+  ${media.mobile`
+    width: 92px;
+    padding: 0 8.2px;
+  `}
 `;
 
 const primaryRatingStyle = css`
@@ -39,6 +44,9 @@ const reviewItemRatingStyle = css`
   width: 110px;
   height: 22px;
   background-size: 22px 22px;
+  ${media.mobile`
+  background-size: 14.5px 20px;
+  `}
 `;
 
 const FixedRatingStyle = styled.div<{

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import { styled } from 'styled-components';
 
 import iconPencil from '../assets/icon-pencil.svg';
 import iconPin from '../assets/icon-pin.svg';
+import arrow from '../assets/icons/arrowright.svg';
 import settingIcon from '../assets/icons/setting.svg';
 import iconLogin from '../assets/login-icon.svg';
 import logo from '../assets/logo.svg';
@@ -20,6 +21,7 @@ import { toggleGroup } from '../redux/manageModalSlice';
 import { toggleArtist } from '../redux/manageModalSlice';
 import { toggleCategory } from '../redux/manageModalSlice';
 import { toggleArtistType } from '../redux/manageModalSlice';
+import media from '../utils/mediaQuery';
 import px2vw from '../utils/px2vw';
 
 export const HeaderStyle = styled.header`
@@ -28,11 +30,36 @@ export const HeaderStyle = styled.header`
   justify-content: space-between;
   align-items: center;
   padding: ${px2vw(22)} ${px2vw(142)} ${px2vw(22)};
+  ${media.mobile`
+    padding: 7px 27px;
+    
+  `}
 `;
 
 export const Logo = styled.img`
   width: 249px;
   cursor: pointer;
+  ${media.mobile`
+  display: none;
+  `}
+`;
+
+export const MobileLogo = styled.div`
+  display: none;
+  ${media.mobile`
+  display: flex;
+  align-items: center;
+  &>img {
+    width: 22px;
+    transform: rotate(180deg);
+    margin-right: 18px;
+  }
+  &>span{
+    font-size: 24px;
+    font-style: normal;
+    font-weight: 700;
+  }
+`}
 `;
 
 export const MenuButton = styled(TextButton)`
@@ -40,22 +67,45 @@ export const MenuButton = styled(TextButton)`
   align-items: center;
   padding: 12px 10px;
   height: 36px;
-  font-weight: 700;
-  font-size: 18px;
   margin-right: ${px2vw(18)};
   border: 2px solid #1e232c;
   border-radius: 3px;
   background-color: var(--yellow);
-  box-shadow: 3px 3px 0px 0px #00000040;
+  box-shadow: 3px 3px 0px 0px rgba(0, 0, 0, 0.25);
   text-align: center;
   &:nth-child(3) {
     margin-right: ${px2vw(24)};
   }
+  ${media.mobile`
+  width: 40px;
+  height: 22px;
+  padding: 3px 12px;
+  margin-right: 8px;
+  border: 1.4px solid #1e232c;
+  border-radius: 20px;
+  box-sizing: border-box;
+  box-shadow: 2px 2px 0px 0px rgba(0, 0, 0, 0.25);;
+  &:nth-child(3) {
+    margin-right: 12px;
+  }
+  `}
 `;
 
 const MenuButtonIcon = styled.img`
   height: 22px;
   margin-right: 8px;
+  ${media.mobile`
+    height: 14px;
+    margin-right:0;
+  `}
+`;
+
+const MenuButtonText = styled.span`
+  font-weight: 700;
+  font-size: 18px;
+  ${media.mobile`
+    display: none;
+  `}
 `;
 
 export const RightSection = styled.section`
@@ -76,6 +126,11 @@ export const ProfileImg = styled.img`
   border: 2px solid #1e232c;
   flex-shrink: 0;
   object-fit: cover;
+  ${media.mobile`
+    width: 46px;
+    height: 46px;
+    border: 1.4px solid #1e232c;
+  `}
 `;
 
 const Header: React.FC = ({}) => {
@@ -177,14 +232,14 @@ const Header: React.FC = ({}) => {
     content = managePageMenu.map((menu) => (
       <MenuButton key={menu.id} onClick={menu.handler}>
         <MenuButtonIcon src={menu.icon} />
-        {menu.title}
+        <MenuButtonText>{menu.title}</MenuButtonText>
       </MenuButton>
     ));
   } else {
     content = publicMenu.map((menu) => (
       <MenuButton key={menu.id} onClick={menu.handler}>
         <MenuButtonIcon src={menu.icon} />
-        {menu.title}
+        <MenuButtonText>{menu.title}</MenuButtonText>
       </MenuButton>
     ));
   }
@@ -198,11 +253,21 @@ const Header: React.FC = ({}) => {
           routeTo('/');
         }}
       />
+      {currentPath !== '/' && (
+        <MobileLogo
+          onClick={() => {
+            routeTo('/');
+          }}
+        >
+          <img src={arrow} />
+          <span>홈으로</span>
+        </MobileLogo>
+      )}
       <RightSection>
         {content}
         <MenuButton onClick={handleAuthButton}>
           <MenuButtonIcon src={iconLogin} />
-          {user ? 'Logout' : 'Login'}
+          <MenuButtonText>{user ? 'Logout' : 'Login'}</MenuButtonText>
         </MenuButton>
         <ProfileDropdown>
           <ProfileImg

--- a/src/pages/MyPage/MyPageStyle.tsx
+++ b/src/pages/MyPage/MyPageStyle.tsx
@@ -75,6 +75,7 @@ export const ContentSection = styled.section`
   }
   ${media.mobile`
     width: 90%;
+  height: 578px;
     right: -10px;
     padding: 10px 20px 0 0;
     margin: 0 20px;

--- a/src/pages/MyPage/MyPageStyle.tsx
+++ b/src/pages/MyPage/MyPageStyle.tsx
@@ -55,7 +55,7 @@ export const ContentSection = styled.section`
   position: relative;
   width: 908px;
   height: 695px;
-  padding: 24px 28px;
+  padding: 24px 28px 24px 10px;
   background-color: #f6edb2;
   border: 2px solid var(--line-black);
   border-radius: 20px;

--- a/src/pages/MyPage/MyPageStyle.tsx
+++ b/src/pages/MyPage/MyPageStyle.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 
+import media from '../../utils/mediaQuery';
 import px2vw from '../../utils/px2vw';
 
 export const Main = styled.main`
@@ -9,6 +10,11 @@ export const Main = styled.main`
   width: 100%;
   padding: 0 ${px2vw(142)};
   margin: 0 auto;
+  ${media.mobile`
+    flex-direction: column;
+    align-items: center;
+    padding: 0 ${px2vw(27)};
+  `}
 `;
 
 export const SideSection = styled.section`
@@ -16,11 +22,18 @@ export const SideSection = styled.section`
   flex-direction: column;
   align-items: center;
   width: 20%;
+  ${media.mobile`
+    width: 90%;
+    margin: 0 27px;
+  `}
 `;
 
 export const ProfileWrapper = styled.article`
   margin-bottom: 34px;
   text-align: center;
+  ${media.mobile`
+    display: none;
+  `}
 `;
 
 export const ProfileImg = styled.img`
@@ -40,7 +53,6 @@ export const Username = styled.span`
 
 export const ContentSection = styled.section`
   position: relative;
-  /* width: 80%; */
   width: 908px;
   height: 695px;
   padding: 24px 28px;
@@ -61,6 +73,12 @@ export const ContentSection = styled.section`
     background-color: #fffbe2;
     z-index: -9;
   }
+  ${media.mobile`
+    width: 90%;
+    right: -10px;
+    padding: 10px 20px 0 0;
+    margin: 0 20px;
+  `}
 `;
 
 export const ContentWrapper = styled.div`
@@ -73,6 +91,9 @@ export const ContentWrapper = styled.div`
   overflow-y: scroll;
   &::-webkit-scrollbar {
     width: 20px;
+    ${media.mobile`
+      width: 8px;
+    `}
   }
   &::-webkit-scrollbar-thumb {
     border-radius: 17px;
@@ -85,4 +106,7 @@ export const ContentWrapper = styled.div`
     background-clip: content-box;
     background-color: rgba(176, 180, 204, 0.5);
   }
+  ${media.mobile`
+    height: 96%;
+  `}
 `;

--- a/src/pages/MyPage/SideBarStyle.tsx
+++ b/src/pages/MyPage/SideBarStyle.tsx
@@ -1,6 +1,8 @@
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
+import media from '../../utils/mediaQuery';
+
 type ListLabelProps = {
   selected?: boolean;
   hearticon: string;
@@ -9,7 +11,7 @@ type ListLabelProps = {
 export const SideBarSection = styled.section`
   position: relative;
   width: 231px;
-  min-height: 200px;
+  height: 387px;
   padding: 67px 44px 53px;
   background-color: #fffbe2;
   border: 2px solid var(--line-black);
@@ -26,6 +28,9 @@ export const SideBarSection = styled.section`
     border-bottom: 2px solid var(--line-black);
     border-top-left-radius: 20px;
     border-top-right-radius: 20px;
+    ${media.mobile`
+    height: 22px;
+    `}
   }
   &::after {
     position: absolute;
@@ -39,7 +44,16 @@ export const SideBarSection = styled.section`
     top: 5px;
     right: -10px;
     z-index: -9;
+    ${media.mobile`
+    display: none;
+    `}
   }
+  ${media.mobile`
+    width: 100%;
+    height: 82px;
+    padding: 32px 18px 8px;
+    margin-top: 20px;
+  `}
 `;
 
 export const SpringWrapper = styled.div`
@@ -49,6 +63,9 @@ export const SpringWrapper = styled.div`
   top: -13px;
   right: 50%;
   transform: translateX(50%);
+  ${media.mobile`
+    gap: 20px;
+  `}
 `;
 
 export const Spring = styled.div`
@@ -62,10 +79,22 @@ export const Spring = styled.div`
 export const ListsWrapper = styled.article`
   display: flex;
   flex-direction: column;
+  ${media.mobile`
+  flex-direction: row;   
+  align-items: center;
+    width: 100%;
+    gap: 10px;
+  `}
 `;
 
 export const List = styled.div`
   margin-bottom: 15px;
+  ${media.mobile`
+  width: 45px;
+  margin-bottom: 0;
+  text-align: center;
+  white-space: pre-wrap; 
+  `}
 `;
 
 export const ListLink = styled(Link)<ListLabelProps>`
@@ -86,6 +115,11 @@ export const ListLink = styled(Link)<ListLabelProps>`
       left: -20px;
     }
   `}
+  &::before {
+    ${media.mobile`
+    display: none;
+    `}
+  }
   &::after {
     position: absolute;
     display: block;
@@ -97,5 +131,15 @@ export const ListLink = styled(Link)<ListLabelProps>`
     bottom: 3px;
     left: 5px;
     border-radius: 5px;
+    ${media.mobile`
+    display: none;
+    `}
   }
+
+  ${media.mobile`
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+  `}
 `;

--- a/src/pages/MyPage/components/BookmarkEventItem.tsx
+++ b/src/pages/MyPage/components/BookmarkEventItem.tsx
@@ -13,8 +13,8 @@ import {
   EventImg,
   EventName,
   EventSettingIconsWrapper,
-  SettingIcon,
 } from './BookmarkEventItemStyle';
+import { SettingIcon } from './BookmarkFolderItemStyle';
 
 type EventItemProps = {
   image: string;

--- a/src/pages/MyPage/components/BookmarkEventItemStyle.tsx
+++ b/src/pages/MyPage/components/BookmarkEventItemStyle.tsx
@@ -1,6 +1,7 @@
 import styled, { keyframes } from 'styled-components';
 
 import bookmarkicon from '../../../assets/icons/bookmark.svg';
+import media from '../../../utils/mediaQuery';
 
 import { SettingIconsWrapper } from './BookmarkFolderItemStyle';
 
@@ -36,6 +37,9 @@ export const ItemWrapper = styled.div<EventItemProps>`
     top: -4px;
     left: 19px;
   }
+  ${media.mobile`
+    width: 134px;
+  `}
 `;
 
 export const EventImg = styled.img`
@@ -59,6 +63,11 @@ export const EventName = styled.span`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  ${media.mobile`
+  width: 134px;
+  height: 24px;
+  padding: 2px 6px;
+  `}
 `;
 
 export const SettingIcon = styled.span`

--- a/src/pages/MyPage/components/BookmarkEventItemStyle.tsx
+++ b/src/pages/MyPage/components/BookmarkEventItemStyle.tsx
@@ -38,7 +38,9 @@ export const ItemWrapper = styled.div<EventItemProps>`
     left: 19px;
   }
   ${media.mobile`
-    width: 134px;
+  width: 50%;
+  gap: 9px;
+  margin-bottom: 12px;
   `}
 `;
 
@@ -48,6 +50,9 @@ export const EventImg = styled.img`
   border: 2px solid var(--line-black);
   border-radius: 20px;
   object-fit: cover;
+  ${media.mobile`
+    width: 95%;
+  `}
 `;
 
 export const EventName = styled.span`
@@ -64,7 +69,8 @@ export const EventName = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
   ${media.mobile`
-  width: 134px;
+  width: 95%;
+  /* width: 134px; */
   height: 24px;
   padding: 2px 6px;
   `}
@@ -89,4 +95,7 @@ export const SettingIcon = styled.span`
 export const EventSettingIconsWrapper = styled(SettingIconsWrapper)`
   top: -6%;
   right: -5%;
+  ${media.mobile`
+    right: 0;
+  `}
 `;

--- a/src/pages/MyPage/components/BookmarkEvents.tsx
+++ b/src/pages/MyPage/components/BookmarkEvents.tsx
@@ -10,6 +10,15 @@ import { BookmarkEventType } from '../../../types/bookmarkEventType';
 
 import BookmarkEventItem from './BookmarkEventItem';
 import * as S from './BookmarkEventsStyle';
+import {
+  Path,
+  Star,
+  GoBookmarkFolders,
+  SettingBtnWrapper,
+  SettingBtnText,
+  SettingBtn,
+  GoEditBtn,
+} from './BookmarkFoldersStyle';
 
 type EventsProps = {
   foldername: string;
@@ -86,29 +95,29 @@ const BookmarkEvents = ({
   return (
     <>
       <S.EventsHeader>
-        <S.Path>
-          <img src={starticon} />
-          <S.GoBookmarkFolders onClick={onClickGoBookmarkFolders}>
+        <Path>
+          <Star src={starticon} />
+          <GoBookmarkFolders onClick={onClickGoBookmarkFolders}>
             북마크
-          </S.GoBookmarkFolders>
-          <img src={arrowicon} />
+          </GoBookmarkFolders>
+          <S.Arrow src={arrowicon} />
           <span>{foldername}</span>
-        </S.Path>
-        <S.SettingBtnWrapper>
+        </Path>
+        <SettingBtnWrapper>
           <CopyToClipboard text={originPath + folderPath} onCopy={onCopyURL}>
-            <S.SettingBtn>
+            <SettingBtn>
               <img src={plusicon} />
-              폴더 공유하기
-            </S.SettingBtn>
+              <SettingBtnText>폴더 공유하기</SettingBtnText>
+            </SettingBtn>
           </CopyToClipboard>
-          <S.GoEditBtn
+          <GoEditBtn
             onClick={onClickToggleEditmode}
             editmode={isEditmode ? isEditmode.toString() : undefined}
           >
             <img src={editicon} />
-            북마크 편집하기
-          </S.GoEditBtn>
-        </S.SettingBtnWrapper>
+            <SettingBtnText>북마크 편집하기</SettingBtnText>
+          </GoEditBtn>
+        </SettingBtnWrapper>
       </S.EventsHeader>
       <S.EventsContainer onClick={onClickNoEditmode}>
         {hasEvents ? content : <div>북마크된 이벤트가 없습니다.</div>}

--- a/src/pages/MyPage/components/BookmarkEventsStyle.tsx
+++ b/src/pages/MyPage/components/BookmarkEventsStyle.tsx
@@ -1,60 +1,17 @@
 import styled from 'styled-components';
 
+import media from '../../../utils/mediaQuery';
+
 import { SettingIconsWrapper } from './BookmarkFolderItemStyle';
 import { FoldersHeader, FoldersContainer } from './BookmarkFoldersStyle';
 
-type EditBtnProps = {
-  editmode: string | undefined;
-};
-
-export const GoBookmarkFolders = styled.span`
-  cursor: pointer;
-`;
-
-export const Path = styled.div`
-  display: flex;
-  align-items: center;
-  & > img {
-    margin-right: 10px;
-  }
-  & > span {
-    margin-right: 10px;
-    font-size: 20px;
-    font-weight: 700;
-    line-height: normal;
-  }
-`;
-
-export const SettingBtnWrapper = styled.div`
-  display: flex;
-  gap: 12px;
-`;
-
-export const SettingBtn = styled.button`
-  display: flex;
-  align-items: center;
-  padding: 4px 12px;
-  font-size: 14px;
-  font-weight: 700;
-  line-height: normal;
-  border: 2px solid var(--line-black);
-  border-radius: 20px;
-  background-color: #defcf9;
-  box-shadow: 4px 4px 0px 0px rgba(0, 0, 0, 0.25);
-  cursor: pointer;
-  & > img {
-    margin-right: 10px;
-  }
-`;
-
-export const GoEditBtn = styled(SettingBtn)<EditBtnProps>`
-  ${(props) =>
-    props.editmode &&
-    `
-  background-color: #B7EDE8;
+export const Arrow = styled.img`
+  margin-right: 10px;
+  ${media.mobile`
+    margin-right: 6px;
+  
 `}
 `;
-
 export const EventsHeader = styled(FoldersHeader)``;
 
 export const EventsContainer = styled(FoldersContainer)``;

--- a/src/pages/MyPage/components/BookmarkFolderItem.tsx
+++ b/src/pages/MyPage/components/BookmarkFolderItem.tsx
@@ -1,6 +1,6 @@
 import { useDispatch } from 'react-redux';
 
-import { ReactComponent as Bookmarkfoldericon } from '../../../assets/icons/bookmark-folder.svg';
+// import { ReactComponent as Bookmarkfoldericon } from '../../../assets/icons/bookmark-folder.svg';
 import deleteicon from '../../../assets/icons/crosspink.svg';
 import pencilicon from '../../../assets/icons/editpencilbig.svg';
 import { emojiArray } from '../../../components/modals/EmojiArray';
@@ -68,7 +68,7 @@ const BookmarkFolderItem = ({
 
   return (
     <S.FolderWrapper onClick={onClickFolder}>
-      <Bookmarkfoldericon fill={color} />
+      <S.StyledFolderIcon fill={color} />
       <S.EmojiPreview img={folderEmoji}>
         <img
           src={emojiArray.find((emoji) => emoji.value === folderEmoji)?.img}

--- a/src/pages/MyPage/components/BookmarkFolderItemStyle.tsx
+++ b/src/pages/MyPage/components/BookmarkFolderItemStyle.tsx
@@ -1,5 +1,6 @@
 import styled, { keyframes } from 'styled-components';
 
+import { ReactComponent as Bookmarkfoldericon } from '../../../assets/icons/bookmark-folder.svg';
 import media from '../../../utils/mediaQuery';
 
 type EmojiPreviewType = {
@@ -24,8 +25,14 @@ export const FolderWrapper = styled.div`
   width: 142px;
   cursor: pointer;
   ${media.mobile`
-    width: 138px;
+  width: 50%;
+  gap: 0px;
   `}
+`;
+
+export const StyledFolderIcon = styled(Bookmarkfoldericon)`
+  width: 90%;
+  max-width: 135px;
 `;
 
 export const EmojiPreview = styled.span<EmojiPreviewType>`
@@ -33,29 +40,20 @@ export const EmojiPreview = styled.span<EmojiPreviewType>`
   display: flex;
   justify-content: center;
   align-items: center;
-  top: 40%;
-  left: 15px;
-  transform: translate(50%, -50%);
-  width: 54px;
-  height: 54px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -75%);
+  min-width: 54px;
+  min-height: 54px;
   border: 2px solid var(--line-black);
-  border-radius: 50%;
+  border-radius: 100%;
   background-color: white;
   & > img {
-    width: 30px;
-    height: 30px;
+    max-width: 30px;
+    max-height: 30px;
   }
-`;
-
-export const FolderNameWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 6px;
-  width: 142px;
-  margin: 0 auto;
   ${media.mobile`
-    gap: 4px;
+    top: 55%;
   `}
 `;
 
@@ -65,6 +63,10 @@ export const SettingIconsWrapper = styled.div`
   gap: 2px;
   top: 3px;
   right: 0;
+  ${media.mobile`
+    top: 12px;
+    right: 5px;
+  `}
 `;
 
 export const SettingIcon = styled.span`
@@ -88,6 +90,19 @@ export const SettingIcon = styled.span`
       width: 12px;
       height: 12px;
     }
+  `}
+`;
+
+export const FolderNameWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  margin: 0 auto;
+  ${media.mobile`
+    width: 95%;
+    gap: 3px;
   `}
 `;
 
@@ -127,7 +142,7 @@ export const FolderName = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
   ${media.mobile`
-  width: 105px;
+  width: 80%;
   height: 24px;
   padding: 3px 6px;
   `}

--- a/src/pages/MyPage/components/BookmarkFolderItemStyle.tsx
+++ b/src/pages/MyPage/components/BookmarkFolderItemStyle.tsx
@@ -1,5 +1,7 @@
 import styled, { keyframes } from 'styled-components';
 
+import media from '../../../utils/mediaQuery';
+
 type EmojiPreviewType = {
   img: string;
 };
@@ -21,6 +23,9 @@ export const FolderWrapper = styled.div`
   gap: 10px;
   width: 142px;
   cursor: pointer;
+  ${media.mobile`
+    width: 138px;
+  `}
 `;
 
 export const EmojiPreview = styled.span<EmojiPreviewType>`
@@ -49,6 +54,9 @@ export const FolderNameWrapper = styled.div`
   gap: 6px;
   width: 142px;
   margin: 0 auto;
+  ${media.mobile`
+    gap: 4px;
+  `}
 `;
 
 export const SettingIconsWrapper = styled.div`
@@ -73,6 +81,14 @@ export const SettingIcon = styled.span`
   animation: ${shaking} 0.15s infinite linear alternate;
   will-change: transform;
   cursor: pointer;
+  ${media.mobile`
+    width: 22.5px;
+    height: 22.5px;
+    &>img{
+      width: 12px;
+      height: 12px;
+    }
+  `}
 `;
 
 export const NameIcon = styled.button`
@@ -102,6 +118,7 @@ export const FolderName = styled.span`
   font-size: 14px;
   font-weight: 700;
   text-align: center;
+  color: #4e5761;
   border: 2px solid #4e5761;
   border-radius: 20px;
   background-color: #f8f8fa;
@@ -109,4 +126,9 @@ export const FolderName = styled.span`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  ${media.mobile`
+  width: 105px;
+  height: 24px;
+  padding: 3px 6px;
+  `}
 `;

--- a/src/pages/MyPage/components/BookmarkFolders.tsx
+++ b/src/pages/MyPage/components/BookmarkFolders.tsx
@@ -88,14 +88,14 @@ const BookmarkFolders = ({
         <S.SettingBtnWrapper>
           <S.SettingBtn onClick={onClickAddNewFolder}>
             <img src={plusicon} />
-            북마크 폴더 추가하기
+            <S.SettingBtnText>북마크 폴더 추가하기</S.SettingBtnText>
           </S.SettingBtn>
           <S.GoEditBtn
             onClick={onClickToggleEditmode}
             editmode={isEditmode ? isEditmode.toString() : undefined}
           >
             <img src={editicon} />
-            북마크 편집하기
+            <S.SettingBtnText>북마크 편집하기</S.SettingBtnText>
           </S.GoEditBtn>
         </S.SettingBtnWrapper>
       </S.FoldersHeader>

--- a/src/pages/MyPage/components/BookmarkFolders.tsx
+++ b/src/pages/MyPage/components/BookmarkFolders.tsx
@@ -82,7 +82,7 @@ const BookmarkFolders = ({
     <>
       <S.FoldersHeader>
         <S.Path>
-          <img src={starticon} />
+          <S.Star src={starticon} />
           <span>북마크</span>
         </S.Path>
         <S.SettingBtnWrapper>

--- a/src/pages/MyPage/components/BookmarkFoldersStyle.tsx
+++ b/src/pages/MyPage/components/BookmarkFoldersStyle.tsx
@@ -30,7 +30,6 @@ export const Path = styled.div`
   display: flex;
   align-items: center;
   & > span {
-    margin-right: 10px;
     font-size: 20px;
     font-weight: 700;
     line-height: normal;
@@ -57,7 +56,11 @@ export const Star = styled.img`
 `;
 
 export const GoBookmarkFolders = styled.span`
+  margin-right: 10px;
   cursor: pointer;
+  ${media.mobile`
+    margin-right: 5px;
+  `}
 `;
 
 export const SettingBtnWrapper = styled.div`
@@ -107,10 +110,11 @@ export const GoEditBtn = styled(SettingBtn)<EditBtnProps>`
 `;
 
 export const FoldersContainer = styled.div`
+  position: relative;
   display: flex;
   flex-wrap: wrap;
   gap: 20px;
   ${media.mobile`
-    gap: 13px;
+    gap: 0px;
   `}
 `;

--- a/src/pages/MyPage/components/BookmarkFoldersStyle.tsx
+++ b/src/pages/MyPage/components/BookmarkFoldersStyle.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
+import media from '../../../utils/mediaQuery';
+
 type EditBtnProps = {
   editmode: string | undefined;
 };
@@ -36,6 +38,18 @@ export const Path = styled.div`
     font-weight: 700;
     line-height: normal;
   }
+  ${media.mobile`
+    & > img {
+      width: 16px;
+      margin-left: 10px;
+    }
+    & > span {
+      font-size: 16px;
+      font-style: normal;
+      font-weight: 700;
+      line-height: normal;
+    }
+  `}
 `;
 
 export const GoBookmarkFolders = styled.span`
@@ -45,15 +59,23 @@ export const GoBookmarkFolders = styled.span`
 export const SettingBtnWrapper = styled.div`
   display: flex;
   gap: 12px;
+  ${media.mobile`
+    gap: 10px;
+  `}
 `;
 
+export const SettingBtnText = styled.span`
+  font-size: 14px;
+  font-weight: 700;
+  line-height: normal;
+  ${media.mobile`
+    display: none;
+  `}
+`;
 export const SettingBtn = styled.button`
   display: flex;
   align-items: center;
   padding: 4px 12px;
-  font-size: 14px;
-  font-weight: 700;
-  line-height: normal;
   border: 2px solid var(--line-black);
   border-radius: 20px;
   background-color: #defcf9;
@@ -62,6 +84,14 @@ export const SettingBtn = styled.button`
   & > img {
     margin-right: 10px;
   }
+  ${media.mobile`
+  min-width: 46px;
+  & > img {
+    width: 14px;
+    height: 12px;
+    margin: 0 auto;
+  }
+  `}
 `;
 
 export const GoEditBtn = styled(SettingBtn)<EditBtnProps>`
@@ -76,4 +106,7 @@ export const FoldersContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 20px;
+  ${media.mobile`
+    gap: 13px;
+  `}
 `;

--- a/src/pages/MyPage/components/BookmarkFoldersStyle.tsx
+++ b/src/pages/MyPage/components/BookmarkFoldersStyle.tsx
@@ -29,9 +29,6 @@ export const FoldersHeader = styled.div`
 export const Path = styled.div`
   display: flex;
   align-items: center;
-  & > img {
-    margin-right: 10px;
-  }
   & > span {
     margin-right: 10px;
     font-size: 20px;
@@ -39,16 +36,23 @@ export const Path = styled.div`
     line-height: normal;
   }
   ${media.mobile`
-    & > img {
-      width: 16px;
-      margin-left: 10px;
-    }
     & > span {
       font-size: 16px;
       font-style: normal;
       font-weight: 700;
       line-height: normal;
     }
+  `}
+`;
+
+export const Star = styled.img`
+  margin-right: 10px;
+
+  ${media.mobile`
+      width: 16px;
+      height: 16px;
+      margin: 0 6px 0 10px;
+    
   `}
 `;
 

--- a/src/pages/MyPage/components/BookmarkStyle.tsx
+++ b/src/pages/MyPage/components/BookmarkStyle.tsx
@@ -1,6 +1,11 @@
 import styled from 'styled-components';
 
+import media from '../../../utils/mediaQuery';
+
 export const BookmarkWrapper = styled.section`
   width: 100%;
   padding-right: 30px;
+  ${media.mobile`
+    padding-right: 8px;
+  `}
 `;

--- a/src/pages/MyPage/components/ChangePasswordStyle.tsx
+++ b/src/pages/MyPage/components/ChangePasswordStyle.tsx
@@ -1,12 +1,18 @@
 import styled from 'styled-components';
 
+import media from '../../../utils/mediaQuery';
+
 export const ChangePasswordForm = styled.form`
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: 100%;
+  height: 90%;
+  ${media.mobile`
+    margin-top: 110px;
+    margin-bottom: 20px;
+  `}
 `;
 
 export const UserInfoWrapper = styled.div`
@@ -15,12 +21,20 @@ export const UserInfoWrapper = styled.div`
   justify-content: space-between;
   width: 458px;
   margin-bottom: 22px;
+  ${media.mobile`
+    width: 100%;
+    padding-left: 10px;
+  `}
 `;
 
 export const StyledLabel = styled.label`
   font-size: 20px;
   font-weight: 700;
   line-height: normal;
+  ${media.mobile`
+  width: 45%;
+    font-size: 16px;
+  `}
 `;
 
 export const StyledInput = styled.input`
@@ -31,6 +45,9 @@ export const StyledInput = styled.input`
   font-weight: 400;
   line-height: normal;
   border-radius: 20px;
+  ${media.mobile`
+    width: 90%;
+  `}
 `;
 
 export const PasswordInput = styled(StyledInput)`
@@ -41,7 +58,7 @@ export const PasswordInput = styled(StyledInput)`
 
 export const EditSubmitBtn = styled.button`
   width: 474px;
-  margin: 201px 0 0;
+  margin-top: 201px;
   padding: 17px;
   color: var(--font-black);
   font-size: 24px;
@@ -51,4 +68,8 @@ export const EditSubmitBtn = styled.button`
   border-radius: 50px;
   background-color: #defcf9;
   box-shadow: 4px 4px 0px rgba(0, 0, 0, 0.3);
+  ${media.mobile`
+    width: 50%;
+  padding: 8px;
+  `}
 `;

--- a/src/pages/MyPage/components/EditProfileStyle.tsx
+++ b/src/pages/MyPage/components/EditProfileStyle.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
+import media from '../../../utils/mediaQuery';
+
 type imageType = {
   previewimage: string;
 };
@@ -39,6 +41,11 @@ export const ImagePreview = styled.label<imageType>`
     top: 50%;
     transform: translateY(-50%);
   }
+  ${media.mobile`
+    width:140px;
+    height: 140px;
+    margin-bottom: 48px;
+  `}
 `;
 
 export const HiddenInput = styled.input`
@@ -55,6 +62,10 @@ export const UserInfoWrapper = styled.div`
   display: flex;
   align-items: center;
   margin-bottom: 22px;
+  ${media.mobile`
+    width: 100%;
+    padding-left: 10px;
+  `}
 `;
 
 export const StyledLabel = styled.label`
@@ -63,6 +74,12 @@ export const StyledLabel = styled.label`
   font-size: 20px;
   font-weight: 700;
   line-height: normal;
+  ${media.mobile`
+  position: relative;
+    width: 20%;
+    left: 0px;
+    font-size: 16px;
+  `}
 `;
 
 export const StyledInput = styled.input`
@@ -74,6 +91,10 @@ export const StyledInput = styled.input`
   font-weight: 400;
   line-height: normal;
   border-radius: 20px;
+  ${media.mobile`
+    width: 80%;
+    margin-left: 14px;
+  `}
 `;
 
 export const EmailInput = styled(StyledInput)`
@@ -89,6 +110,15 @@ export const UsernameInput = styled(StyledInput)`
 
 export const BtnWrapper = styled.section`
   margin-top: 102px;
+  ${media.mobile`
+  display: flex;
+  flex-direction: column-reverse;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+  width: 100%;
+  margin-top: 74px;
+  `}
 `;
 
 export const StyledBtn = styled.button`
@@ -99,6 +129,10 @@ export const StyledBtn = styled.button`
   line-height: normal;
   border-radius: 50px;
   box-shadow: 4px 4px 0px rgba(0, 0, 0, 0.3);
+  ${media.mobile`
+    width: 90%;
+    padding: 9px;
+  `}
 `;
 
 export const UnregisterBtn = styled(StyledBtn)`
@@ -106,6 +140,9 @@ export const UnregisterBtn = styled(StyledBtn)`
   color: #8b8e97;
   border: 2px solid #8b8e97;
   background-color: #e7efee;
+  ${media.mobile`
+    margin: 0 auto;
+  `}
 `;
 
 export const EditSubmitBtn = styled(StyledBtn)`

--- a/src/pages/MyPage/components/Event.tsx
+++ b/src/pages/MyPage/components/Event.tsx
@@ -9,19 +9,23 @@ import {
 import { myevetType } from '../../../types/mypageType';
 
 import {
-  TypeInfoBtn,
   EventWrapper,
-  EventImg,
+  EventControlsWrapper,
+  EditBtn,
+  DeleteBtn,
+  EventContainer,
+  BtnText,
+} from './EventStyle';
+import {
+  InfoSection,
   ArtistInfo,
+  ArtistName,
   EventTypeWrapper,
+  TypeInfoBtn,
   StoreName,
   Adress,
-  EventControlsWrapper,
-  EditEventBtn,
-  DeleteEventBtn,
-  ArtistName,
-  EventContainer,
-} from './EventStyle';
+  EventImg,
+} from './LikeStyle';
 
 type LikeItemProps = {
   artists: [
@@ -93,7 +97,7 @@ const EventItem = ({
   return (
     <EventWrapper icon={usericon} onClick={onClickEventItem}>
       <EventImg src={imagePath} />
-      <section>
+      <InfoSection>
         <ArtistInfo>
           {artists.map((artist) => (
             <ArtistName key={artist.id}>{artist.name}</ArtistName>
@@ -107,14 +111,14 @@ const EventItem = ({
         <StoreName>{storeName}</StoreName>
         <Adress>{address}</Adress>
         <EventControlsWrapper>
-          <EditEventBtn type="button" onClick={onClickEditBtn}>
-            수정하기
-          </EditEventBtn>
-          <DeleteEventBtn type="button" onClick={onClickDeleteBtn}>
-            삭제하기
-          </DeleteEventBtn>
+          <EditBtn type="button" onClick={onClickEditBtn}>
+            <BtnText>수정하기</BtnText>
+          </EditBtn>
+          <DeleteBtn type="button" onClick={onClickDeleteBtn}>
+            <BtnText>삭제하기</BtnText>
+          </DeleteBtn>
         </EventControlsWrapper>
-      </section>
+      </InfoSection>
     </EventWrapper>
   );
 };

--- a/src/pages/MyPage/components/EventStyle.tsx
+++ b/src/pages/MyPage/components/EventStyle.tsx
@@ -3,102 +3,14 @@ import styled from 'styled-components';
 import deleteicon from '../../../assets/icons/delete.svg';
 import editicon from '../../../assets/icons/edit.svg';
 import usericon from '../../../assets/icons/mypage.svg';
+import media from '../../../utils/mediaQuery';
 
-type EventWrapperProps = {
-  icon: string;
-};
+import { LikeWrapper } from './LikeStyle';
 
-export const EventWrapper = styled.article<EventWrapperProps>`
-  position: relative;
-  display: flex;
-  justify-content: start;
-  align-items: center;
-  gap: 14px;
-  width: 100%;
-  height: 154px;
-  padding: 11px 20px;
-  margin-top: 22px;
-  margin-right: 34px;
-  border: 2px solid var(--line-black);
-  border-radius: 20px;
-  background-color: #f8f8fa;
-  cursor: pointer;
+export const EventWrapper = styled(LikeWrapper)`
   &::after {
-    position: absolute;
-    display: block;
-    content: '';
-    width: 28px;
-    height: 22px;
-    top: -27px;
-    padding: 12px;
-    border: 2px solid var(--line-black);
-    border-top-right-radius: 20px;
-    border-top-left-radius: 20px;
-    background-color: #d7f5ff;
     background-image: url(${usericon});
-    background-repeat: no-repeat;
-    background-position: center;
-    box-sizing: border-box;
-    z-index: -1;
   }
-`;
-
-export const EventImg = styled.img`
-  width: 124px;
-  height: 124px;
-  border: 2px solid var(--line-black);
-  border-radius: 20px;
-  object-fit: cover;
-`;
-
-export const ArtistInfo = styled.div`
-  font-size: 14px;
-  font-weight: 400;
-  margin-bottom: 7.6px;
-`;
-
-export const GroupName = styled.span`
-  font-size: 16px;
-  font-weight: 700;
-`;
-
-export const ArtistName = styled.span`
-  font-size: 16px;
-  font-weight: 700;
-  margin-right: 5px;
-`;
-
-export const EventTypeWrapper = styled.div`
-  display: flex;
-  gap: 10px;
-  margin-bottom: 12px;
-`;
-
-export const TypeInfoBtn = styled.span`
-  min-width: 68px;
-  padding: 5px 20px;
-  font-size: 14px;
-  font-weight: 400;
-  text-align: center;
-  line-height: normal;
-  border: 2px solid #a0a0a0;
-  border-radius: 30px;
-  background-color: #f5edff;
-`;
-
-export const StoreName = styled.span`
-  display: block;
-  margin-bottom: 8px;
-  font-size: 16px;
-  font-weight: 700;
-  line-height: normal;
-`;
-
-export const Adress = styled.span`
-  display: block;
-  font-size: 16px;
-  font-weight: 700;
-  line-height: normal;
 `;
 
 export const EventControlsWrapper = styled.div`
@@ -111,19 +23,21 @@ export const EventControlsWrapper = styled.div`
 
 const StyledBtn = styled.button`
   position: relative;
-  min-width: 102px;
+  width: 102px;
   height: 28px;
   padding: 4px 12px 4px 32px;
-  font-size: 14px;
-  font-weight: 700;
-  line-height: normal;
   text-align: center;
   border: 2px solid var(--line-black);
   border-radius: 20px 20px 0 0;
   background-color: #fff3ac;
+  ${media.mobile`
+    width: 28px;
+    padding: 0;
+    z-index: -1;
+  `}
 `;
 
-export const EditEventBtn = styled(StyledBtn)`
+export const EditBtn = styled(StyledBtn)`
   &::before {
     position: absolute;
     display: block;
@@ -135,10 +49,15 @@ export const EditEventBtn = styled(StyledBtn)`
     background-image: url(${editicon});
     background-repeat: no-repeat;
     background-position: center;
+    ${media.mobile`
+    width: 14px;
+    top: 3px;
+      left: 5px;
+    `}
   }
 `;
 
-export const DeleteEventBtn = styled(StyledBtn)`
+export const DeleteBtn = styled(StyledBtn)`
   &::before {
     position: absolute;
     display: block;
@@ -150,9 +69,22 @@ export const DeleteEventBtn = styled(StyledBtn)`
     background-image: url(${deleteicon});
     background-repeat: no-repeat;
     background-position: center;
+    ${media.mobile`
+    width: 15px;
+    top: 1px;
+    left: 5px;
+    `}
   }
 `;
 
+export const BtnText = styled.span`
+  font-size: 14px;
+  font-weight: 700;
+  line-height: normal;
+  ${media.mobile`
+    display: none;
+  `}
+`;
 export const EventContainer = styled.section`
   display: flex;
   flex-direction: column;

--- a/src/pages/MyPage/components/Like.tsx
+++ b/src/pages/MyPage/components/Like.tsx
@@ -6,9 +6,11 @@ import { useGetMylikeQuery } from '../../../redux/mypageSlice';
 import { mylikeType } from '../../../types/mypageType';
 
 import {
+  LikeContainer,
   TypeInfoBtn,
   LikeWrapper,
   EventImg,
+  InfoSection,
   ArtistInfo,
   ArtistName,
   EventTypeWrapper,
@@ -65,7 +67,7 @@ const LikeItem = ({
   return (
     <LikeWrapper icon={hearticon} onClick={onClickMyLike}>
       <EventImg src={imgURL} />
-      <section>
+      <InfoSection>
         <ArtistInfo>
           {artists.map((artist) => (
             <ArtistName key={artist.id}>{artist.name}</ArtistName>
@@ -78,7 +80,7 @@ const LikeItem = ({
         </EventTypeWrapper>
         <StoreName>{storeName}</StoreName>
         <Adress>{address}</Adress>
-      </section>
+      </InfoSection>
     </LikeWrapper>
   );
 };
@@ -128,13 +130,13 @@ const Like = () => {
     content = <div>{error.toString()}</div>;
   }
   return (
-    <>
+    <LikeContainer>
       {numberOfMylike ? (
         <div>{content}</div>
       ) : (
         <div>좋아요 이벤트가 없습니다.</div>
       )}
-    </>
+    </LikeContainer>
   );
 };
 

--- a/src/pages/MyPage/components/LikeStyle.tsx
+++ b/src/pages/MyPage/components/LikeStyle.tsx
@@ -1,10 +1,16 @@
 import styled from 'styled-components';
 
 import heartIcon from '../../../assets/icons/heart-big.svg';
+import media from '../../../utils/mediaQuery';
 
 type LikeWrapperProps = {
   icon: string;
 };
+
+export const LikeContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+`;
 
 export const LikeWrapper = styled.article<LikeWrapperProps>`
   position: relative;
@@ -12,21 +18,25 @@ export const LikeWrapper = styled.article<LikeWrapperProps>`
   justify-content: start;
   align-items: center;
   gap: 14px;
-  width: 100%;
+  width: 96%;
   padding: 11px 20px;
-  margin-top: 22px;
+  margin-top: 38px;
   margin-right: 34px;
   border: 2px solid var(--line-black);
   border-radius: 20px;
   background-color: #f8f8fa;
+  box-sizing: border-box;
   cursor: pointer;
+  &:first-of-type {
+    margin-top: 22px;
+  }
   &::after {
     position: absolute;
     display: block;
     content: '';
     width: 28px;
     height: 22px;
-    top: -25px;
+    top: -26px;
     padding: 12px;
     border: 2px solid var(--line-black);
     border-top-right-radius: 20px;
@@ -37,7 +47,16 @@ export const LikeWrapper = styled.article<LikeWrapperProps>`
     background-position: center;
     box-sizing: border-box;
     z-index: -1;
+    ${media.mobile`
+      left: 18px;
+    `}
   }
+  ${media.mobile`
+    flex-direction: column;
+    gap: 6px;
+    height: 214px;
+    padding: 0;
+  `}
 `;
 
 export const EventImg = styled.img`
@@ -46,12 +65,28 @@ export const EventImg = styled.img`
   border: 2px solid var(--line-black);
   border-radius: 20px;
   object-fit: cover;
+  ${media.mobile`
+    width: 101.5%;
+    height: 90px;
+    position: relative;
+    top: -3px;
+  `}
+`;
+
+export const InfoSection = styled.section`
+  ${media.mobile`
+    width: 100%;
+    padding: 0 12px;
+  `}
 `;
 
 export const ArtistInfo = styled.div`
   font-size: 14px;
   font-weight: 400;
   margin-bottom: 7.6px;
+  ${media.mobile`
+  margin-bottom: 6px;
+  `}
 `;
 
 export const ArtistName = styled.span`
@@ -64,10 +99,11 @@ export const EventTypeWrapper = styled.div`
   display: flex;
   gap: 10px;
   margin-bottom: 12px;
+  ${media.mobile`
+  `}
 `;
 
 export const TypeInfoBtn = styled.span`
-  min-width: 68px;
   padding: 5px 20px;
   font-size: 14px;
   font-weight: 400;
@@ -76,6 +112,10 @@ export const TypeInfoBtn = styled.span`
   border: 2px solid #a0a0a0;
   border-radius: 30px;
   background-color: #f5edff;
+  ${media.mobile`
+  padding: 3px 14px;
+    font-size: 10px;
+  `}
 `;
 
 export const StoreName = styled.span`
@@ -84,6 +124,10 @@ export const StoreName = styled.span`
   font-size: 16px;
   font-weight: 700;
   line-height: normal;
+  ${media.mobile`
+    font-size: 14px;
+    margin-bottom: 7px;
+  `}
 `;
 
 export const Adress = styled.span`
@@ -91,4 +135,7 @@ export const Adress = styled.span`
   font-size: 16px;
   font-weight: 700;
   line-height: normal;
+  ${media.mobile`
+    font-size: 14px;
+  `}
 `;

--- a/src/pages/MyPage/components/LikeStyle.tsx
+++ b/src/pages/MyPage/components/LikeStyle.tsx
@@ -99,8 +99,6 @@ export const EventTypeWrapper = styled.div`
   display: flex;
   gap: 10px;
   margin-bottom: 12px;
-  ${media.mobile`
-  `}
 `;
 
 export const TypeInfoBtn = styled.span`

--- a/src/pages/MyPage/components/Review.tsx
+++ b/src/pages/MyPage/components/Review.tsx
@@ -17,6 +17,7 @@ import {
   ButtonWrapper,
   EditButton,
   DeleteButton,
+  ButtonText,
 } from './ReviewStyle';
 
 type ReviewItemProps = {
@@ -72,8 +73,12 @@ const ReviewItem = ({
       <ReviewContent> {content} </ReviewContent>
       <ReviewImg src={baseUrl + reviewImage} />
       <ButtonWrapper>
-        <EditButton onClick={onEditButtonClick}>수정하기</EditButton>
-        <DeleteButton onClick={onDeleteButtonClick}>삭제하기</DeleteButton>
+        <EditButton onClick={onEditButtonClick}>
+          <ButtonText>수정하기</ButtonText>
+        </EditButton>
+        <DeleteButton onClick={onDeleteButtonClick}>
+          <ButtonText>삭제하기</ButtonText>
+        </DeleteButton>
       </ButtonWrapper>
     </ReviewItemWrapper>
   );

--- a/src/pages/MyPage/components/ReviewStyle.tsx
+++ b/src/pages/MyPage/components/ReviewStyle.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 import deleteicon from '../../../assets/icons/delete.svg';
 import editicon from '../../../assets/icons/edit.svg';
+import media from '../../../utils/mediaQuery';
 
 export const ReviewItemWrapper = styled.article`
   width: 390px;
@@ -10,6 +11,10 @@ export const ReviewItemWrapper = styled.article`
   border-radius: 20px;
   background-color: #f8f8fa;
   cursor: pointer;
+  ${media.mobile`
+    width: 100%;
+    padding: 16px 0 11px;
+  `}
 `;
 
 export const ReviewTitle = styled.div`
@@ -17,6 +22,10 @@ export const ReviewTitle = styled.div`
   align-items: center;
   gap: 18px;
   margin: 0 22px 25px;
+  ${media.mobile`
+    gap: 10px;
+    margin-bottom: 10px;
+  `}
 `;
 
 export const EventName = styled.span`
@@ -25,18 +34,32 @@ export const EventName = styled.span`
   font-size: 20px;
   font-weight: 700;
   line-height: normal;
+  ${media.mobile`
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal
+  `}
 `;
 
 export const ReviewContent = styled.section`
   display: -webkit-box;
-  margin: 0 22px 17px;
   height: 60px;
+  margin: 0 22px 17px;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 20px;
   //말줄임
   overflow: hidden;
   text-overflow: ellipsis;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
-  line-height: 20px;
+  ${media.mobile`
+    height: 54px;
+    margin :  0 16px 14px;
+    line-height: 18px;
+  `}
 `;
 
 export const ReviewImg = styled.img`
@@ -46,12 +69,20 @@ export const ReviewImg = styled.img`
   border-bottom: 2px solid var(--line-black);
   object-fit: cover;
   margin-bottom: 8px;
+  ${media.mobile`
+    height: 158px;
+  margin-bottom: 10px;
+  `}
 `;
 
 export const ReviewsWrapper = styled.div`
   display: grid;
   gap: 18px 16px;
   grid-template-columns: repeat(2, 1fr);
+  ${media.mobile`
+  grid-template-columns: repeat(1, 1fr);
+  padding-right: 14px;
+  `}
 `;
 
 export const ButtonWrapper = styled.div`
@@ -65,23 +96,39 @@ export const ButtonWrapper = styled.div`
 const Button = styled.button.attrs({ type: 'button' })`
   width: 100px;
   height: 28px;
-  font-size: 1.4rem;
-  font-weight: 700;
-  line-height: 1.247857142857143;
-  color: #1e232c;
   background-color: #fff3ac;
   border: 2px solid #1e232c;
   border-radius: 20px;
   background-repeat: no-repeat;
   background-position: 0 center;
+  ${media.mobile`
+    width: 42px;
+    height: 24px;
+  `}
 `;
 
 export const EditButton = styled(Button)`
   padding-left: 20px;
   background-image: url(${editicon});
+  ${media.mobile`
+    background-size: 40px 32px;
+  `}
 `;
 
 export const DeleteButton = styled(Button)`
   padding-left: 22px;
   background-image: url(${deleteicon});
+  ${media.mobile`
+    background-size: 40px 30px;
+  `}
+`;
+
+export const ButtonText = styled.span`
+  font-size: 1.4rem;
+  font-weight: 700;
+  line-height: 1.247857142857143;
+  color: #1e232c;
+  ${media.mobile`
+    display: none;
+  `}
 `;

--- a/src/redux/apiSlice.ts
+++ b/src/redux/apiSlice.ts
@@ -58,6 +58,7 @@ export const apiSlice = createApi({
     'BookmarkEvents',
     'Review',
     'Event',
+    'Like',
   ],
   endpoints: () => ({}),
 });

--- a/src/redux/eventApiSlice.ts
+++ b/src/redux/eventApiSlice.ts
@@ -30,7 +30,7 @@ export const eventApiSlice = apiSlice.injectEndpoints({
     }),
     getEventById: builder.query<EventData, string>({
       query: (id) => ({ url: '/events/' + id, method: 'GET' }),
-      providesTags: ['Event', 'BookmarkEvents'],
+      providesTags: ['Event', 'BookmarkEvents', 'Like'],
     }),
     getMainEvent: builder.query<
       GetMainEventTransformedResponse,
@@ -62,7 +62,7 @@ export const eventApiSlice = apiSlice.injectEndpoints({
         const content = response.content;
         return { content };
       },
-      providesTags: ['Event'],
+      providesTags: ['Event', 'BookmarkEvents', 'Like'],
     }),
     getEvent: builder.query<
       GetEventTransformedResponse,
@@ -93,7 +93,7 @@ export const eventApiSlice = apiSlice.injectEndpoints({
         const isLast = response.last;
         return { content, isLast };
       },
-      providesTags: ['Event', 'BookmarkEvents'],
+      providesTags: ['Event', 'BookmarkEvents', 'Like'],
     }),
     editEvent: builder.mutation({
       query: ({ EventData, id }) => ({

--- a/src/redux/eventApiSlice.ts
+++ b/src/redux/eventApiSlice.ts
@@ -108,12 +108,14 @@ export const eventApiSlice = apiSlice.injectEndpoints({
         url: `/events/${id}/likes`,
         method: 'POST',
       }),
+      invalidatesTags: ['Like'],
     }),
     deleteLike: builder.mutation<void, number>({
       query: (id) => ({
         url: `/events/${id}/likes`,
         method: 'DELETE',
       }),
+      invalidatesTags: ['Like'],
     }),
     getTodayHashtags: builder.query<TodayHashtagsResponse[], void>({
       query: () => ({

--- a/src/redux/mypageSlice.ts
+++ b/src/redux/mypageSlice.ts
@@ -36,6 +36,7 @@ export const mypageApiSlice = apiSlice.injectEndpoints({
         const isLast = response.last;
         return { numberOfElements, content, isLast };
       },
+      providesTags: ['Like'],
     }),
     getMyreview: builder.query<
       transformedMyreview,

--- a/src/redux/reviewApiSlice.ts
+++ b/src/redux/reviewApiSlice.ts
@@ -49,6 +49,7 @@ const reviewApiSlice = apiSlice.injectEndpoints({
         const isLast = response.last;
         return { content, isLast };
       },
+      providesTags: ['Review'],
     }),
     addReview: builder.mutation({
       query: (requestData: ReviewData) => ({
@@ -56,6 +57,7 @@ const reviewApiSlice = apiSlice.injectEndpoints({
         method: 'POST',
         body: { ...requestData },
       }),
+      invalidatesTags: ['Review'],
     }),
     getMainReview: builder.query<
       GetMainReviewsTransformedResponse,
@@ -69,12 +71,14 @@ const reviewApiSlice = apiSlice.injectEndpoints({
         const content = response.content;
         return { content };
       },
+      providesTags: ['Review'],
     }),
     getReviewById: builder.query<ReviewById, string>({
       query: (id) => ({
         url: `/reviews/${id}`,
         method: 'GET',
       }),
+      providesTags: ['Review'],
     }),
     editReview: builder.mutation<void, EditReviewReq>({
       query: ({ id, requestData }) => ({
@@ -82,12 +86,14 @@ const reviewApiSlice = apiSlice.injectEndpoints({
         method: 'PUT',
         body: { ...requestData },
       }),
+      invalidatesTags: ['Review'],
     }),
     deleteReview: builder.mutation<void, number>({
       query: (id) => ({
         url: `/reviews/${id}`,
         method: 'DELETE',
       }),
+      invalidatesTags: ['Review'],
     }),
   }),
 });

--- a/src/utils/mediaQuery.ts
+++ b/src/utils/mediaQuery.ts
@@ -1,0 +1,25 @@
+import { CSSProp, css } from 'styled-components';
+
+type MediaQueryProps = {
+  mobile: number;
+};
+
+const sizes: MediaQueryProps = {
+  mobile: 390,
+};
+
+type BackQuoteArgs = string[];
+
+const media = {
+  mobile: (literals: TemplateStringsArray, ...args: BackQuoteArgs): CSSProp =>
+    css`
+      @media only screen and (max-width: ${sizes.mobile}px) {
+        ${css(literals, ...args)}
+      }
+    `,
+} as Record<
+  keyof typeof sizes,
+  (l: TemplateStringsArray, ...p: BackQuoteArgs) => CSSProp
+>;
+
+export default media;


### PR DESCRIPTION
## Describe your changes

- 미디어쿼리 모듈 추가
- 헤더 반응형
- 마이페이지 사이드바, 북마크, 이벤트, 좋아요, 나의 이벤트, 나의 리뷰, 프로필 수정, 비밀번호 변경 반응형
- 좋아요/리뷰/이벤트 api slice에 providesTag, invalidatesTag 추가

## To-do before merge
-  마이페이지 사이드바가 디자인 대로라면 `나의<br/>리뷰` `나의<br/>이벤트` `회원정보<br/>수정` 이런식으로 띄어쓰기를 기준으로 하여 두 줄로 나타나야 하는데, 생각처럼 잘 안되어서 혹시 예징이님은 방법은 아실까 여쭤봅니다! 밑에 스크린샷 보시면 더 잘 이해가 되실 거 같아요.
- 사이드바에서 항목 선택 시 하트 이모지가 나타나야하는데, 피그마에서 이 하트 이모지에 접근을 할 수가 없어 레나님께 요청드리겠습니다.

## Screenshot

![image](https://github.com/duck-map-project/duck-map-fe/assets/89509857/ac555e6e-431a-4e6e-9b90-c8dd639a4226)
![image](https://github.com/duck-map-project/duck-map-fe/assets/89509857/3cd5c428-3979-4f23-aca4-4897b24cd69b)

