### PR TITLE
모달 컴포넌트 리팩토링

### DIFF
--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -3,7 +3,13 @@ import styled from 'styled-components';
 import timer from '../assets/timer.svg';
 import media from '../utils/mediaQuery';
 
-const Loading = ({ text }: { text: string }) => {
+interface LoadingProps {
+  text?: string;
+}
+
+const Loading = (props: LoadingProps) => {
+  const defaultText = '저장중입니다. 잠시만 기다려주세요.';
+  const { text = defaultText } = props;
   const texts = text.split('.');
   const content = texts.map(
     (text, idx) =>

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -4,13 +4,16 @@ import timer from '../assets/timer.svg';
 import media from '../utils/mediaQuery';
 
 const Loading = ({ text }: { text: string }) => {
-  const texts = text.split('. ');
-  const content = texts.map((text) => (
-    <>
-      <span key={Math.random()}>{text}</span>
-      <br />
-    </>
-  ));
+  const texts = text.split('.');
+  const content = texts.map(
+    (text, idx) =>
+      text && (
+        <p key={idx}>
+          <span key={Math.random()}>{text}</span>
+          <br />
+        </p>
+      )
+  );
 
   return <LoadingWrapper>{content}</LoadingWrapper>;
 };
@@ -28,6 +31,7 @@ export const LoadingWrapper = styled.article`
   text-align: center;
   font-size: 20px;
   font-weight: 700;
+  top: 30%;
   &::before {
     position: absolute;
     top: 0;

--- a/src/components/modal/CommonModal.tsx
+++ b/src/components/modal/CommonModal.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import media from '../../utils/mediaQuery';
 
-type ModalProps = {
+type commonModalProps = {
   className?: string;
   onClick?: () => void;
   children: ReactNode;
@@ -15,7 +15,12 @@ type ModalWidth = {
   width: string | undefined;
 };
 
-const CommonModal = ({ className, onClick, children, width }: ModalProps) => {
+const CommonModal = ({
+  className,
+  onClick,
+  children,
+  width,
+}: commonModalProps) => {
   const preventBubbling = (event: React.MouseEvent) => {
     event.stopPropagation();
   };
@@ -25,20 +30,22 @@ const CommonModal = ({ className, onClick, children, width }: ModalProps) => {
   };
 
   return (
-    <Backdrop className={className} onClick={onClick}>
-      <ModalOverlay
-        onClick={preventBubbling}
-        onSubmit={preventSubmit}
-        width={width}
-      >
-        <ModalContent>{children}</ModalContent>
-      </ModalOverlay>
-    </Backdrop>
+    <ModalPortal>
+      <Backdrop className={className} onClick={onClick}>
+        <ModalOverlay
+          onClick={preventBubbling}
+          onSubmit={preventSubmit}
+          width={width}
+        >
+          <ModalContent>{children}</ModalContent>
+        </ModalOverlay>
+      </Backdrop>
+    </ModalPortal>
   );
 };
 export default CommonModal;
 
-export const ModalPortal = ({ children }: ModalProps) => {
+const ModalPortal = ({ children }: commonModalProps) => {
   const portalElement = document.getElementById('modal')!;
   return ReactDom.createPortal(children, portalElement);
 };

--- a/src/components/modal/TypeButton.tsx
+++ b/src/components/modal/TypeButton.tsx
@@ -3,32 +3,27 @@ import styled from 'styled-components';
 import media from '../../utils/mediaQuery';
 
 type propsType = {
-  data: { id: number; type?: string; category?: string };
+  id: number;
   text: string;
   selected: boolean;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
 type groupType = {
-  type?: string;
   selected: boolean;
 };
 
-const TypeButton = ({ data, text, onChange, selected }: propsType) => {
+const TypeButton = ({ id, text, onChange, selected }: propsType) => {
   return (
     <>
-      <TypeLabel
-        htmlFor={data.id.toString()}
-        type={data.type}
-        selected={selected}
-      >
+      <TypeLabel htmlFor={id.toString()} selected={selected}>
         {text}
       </TypeLabel>
       <StyledInput
         type="radio"
-        id={data.id.toString()}
+        id={id.toString()}
         name="artistType"
-        value={data.id.toString()}
+        value={id.toString()}
         onChange={onChange}
       />
     </>

--- a/src/features/artists/modals/ArtistModal.tsx
+++ b/src/features/artists/modals/ArtistModal.tsx
@@ -133,13 +133,11 @@ const ArtistModal = ({ type, onClose }: ModalProps) => {
       setIsRequesting(true);
 
       if (!artistName) {
-        setIsRequesting(false);
         alert('아티스트 이름을 입력해주세요.');
         throw new Error('Invalid Artist name');
       }
 
       if (!artistImage && !savedImagefile) {
-        setIsRequesting(false);
         alert('아티스트 사진을 업로드 해주세요.');
         throw new Error('Invalid Artist Picture');
       }
@@ -152,6 +150,8 @@ const ArtistModal = ({ type, onClose }: ModalProps) => {
       }
     } catch (error) {
       console.error(error);
+    } finally {
+      setIsRequesting(false);
     }
   };
 
@@ -178,7 +178,6 @@ const ArtistModal = ({ type, onClose }: ModalProps) => {
       };
 
       const res = await addArtist(artistData);
-      setIsRequesting(false);
 
       if ('data' in res) {
         alert('아티스트의 정보가 정상적으로 추가되었습니다');

--- a/src/features/artists/modals/ArtistModal.tsx
+++ b/src/features/artists/modals/ArtistModal.tsx
@@ -196,7 +196,7 @@ const ArtistModal = ({ type, onClose }: ModalProps) => {
     content = artistTypeArray.map((data) => (
       <TypeButton
         key={data.id}
-        data={data}
+        id={data.id}
         text={data.type}
         onChange={onClickArtistType}
         selected={data.id === artistType}

--- a/src/features/artists/modals/ArtistModal.tsx
+++ b/src/features/artists/modals/ArtistModal.tsx
@@ -7,11 +7,7 @@ import Loading from '../../../components/Loading';
 import CommonModal from '../../../components/modal/CommonModal';
 import TypeButton from '../../../components/modal/TypeButton';
 import useImageProcessing from '../../../hooks/useImageProcessing';
-import {
-  ArtistType,
-  EditArtistDataType,
-  ArtistDataType,
-} from '../../../types/artistsType';
+import { ArtistType } from '../../../types/artistsType';
 import { performApiAction } from '../../../utils/apiHelpers';
 import { ModalProps } from '../../modal/modalsSlice';
 import {
@@ -160,12 +156,7 @@ const ArtistModal = ({ type, onClose }: ModalProps) => {
 
         const successMessage = `아티스트의 정보가 정상적으로 추가되었습니다`;
 
-        await performApiAction<ArtistDataType>(
-          data,
-          addArtist,
-          onClose,
-          successMessage
-        );
+        await performApiAction(data, addArtist, onClose, successMessage);
       } else if (type === 'edit' && filename) {
         const data = {
           artistTypeId: artistType,
@@ -176,7 +167,7 @@ const ArtistModal = ({ type, onClose }: ModalProps) => {
 
         const successMessage = `아티스트의 정보가 정상적으로 수정되었습니다`;
 
-        await performApiAction<EditArtistDataType>(
+        await performApiAction(
           { artistId: editData.id, artistValue: data },
           editArtist,
           onClose,

--- a/src/features/artists/modals/ArtistModal.tsx
+++ b/src/features/artists/modals/ArtistModal.tsx
@@ -234,7 +234,7 @@ const ArtistModal = ({ type, onClose }: ModalProps) => {
 
   return (
     <CommonModal className="addGroupModal" onClick={onClose}>
-      {isRequesting && <Loading text="저장중입니다. 잠시만 기다려주세요!" />}
+      {isRequesting && <Loading />}
       <ArtistModalTitle>
         아티스트 {type === 'add' ? '등록' : '수정'}하기
       </ArtistModalTitle>

--- a/src/features/artists/modals/ArtistModal.tsx
+++ b/src/features/artists/modals/ArtistModal.tsx
@@ -64,7 +64,6 @@ const ArtistModal = ({ type, onClose }: ModalProps) => {
   const [savedImagefile, setSavedImagefile] = useState<string | undefined>(
     undefined
   ); // 저장된 이미지의 filename
-  const { uploadImageToServer } = useImageProcessing();
   const [artistName, setArtistName] = useState<string | undefined>(undefined);
   const [artistTypeArray, setArtistTypeArray] = useState<ArtistType[] | []>([]);
   const [SortModal, setSortModal] = useState(false);
@@ -81,7 +80,7 @@ const ArtistModal = ({ type, onClose }: ModalProps) => {
   const [addArtist] = useAddArtistsMutation();
   const [editArtist] = useEditArtistsMutation();
   const editData = useSelector(selectEditArtistSlice);
-
+  const { ImageProcessing } = useImageProcessing();
   useEffect(() => {
     if (type === 'edit') {
       setArtistType(editData.artistTypeId);
@@ -146,7 +145,10 @@ const ArtistModal = ({ type, onClose }: ModalProps) => {
         throw new Error('Invalid Artist Picture');
       }
 
-      const filename = await processImage();
+      const filename = await ImageProcessing({
+        newImage: artistImage,
+        savedImage: savedImagefile,
+      });
 
       if (type === 'add' && filename) {
         const data = {
@@ -185,15 +187,6 @@ const ArtistModal = ({ type, onClose }: ModalProps) => {
       console.error(error);
     } finally {
       setIsRequesting(false);
-    }
-  };
-
-  const processImage = async () => {
-    if (artistImage) {
-      const uploadImage = await uploadImageToServer(artistImage);
-      return uploadImage;
-    } else if (savedImagefile) {
-      return savedImagefile;
     }
   };
 

--- a/src/features/artists/modals/ArtistModal.tsx
+++ b/src/features/artists/modals/ArtistModal.tsx
@@ -4,9 +4,7 @@ import { useSelector } from 'react-redux';
 import closeIcon from '../../../assets/close.svg';
 import photoIcon from '../../../assets/photo.svg';
 import Loading from '../../../components/Loading';
-import CommonModal, {
-  ModalPortal,
-} from '../../../components/modal/CommonModal';
+import CommonModal from '../../../components/modal/CommonModal';
 import TypeButton from '../../../components/modal/TypeButton';
 import useImageProcessing from '../../../hooks/useImageProcessing';
 import { ArtistType } from '../../../types/artistsType';
@@ -209,7 +207,7 @@ const ArtistModal = ({ type, onClose }: ModalProps) => {
         artistId: editData.id,
         artistValue: data,
       });
-      
+
       if ('data' in res) {
         alert('아티스트의 정보가 정상적으로 수정되었습니다');
         onClose();
@@ -236,55 +234,53 @@ const ArtistModal = ({ type, onClose }: ModalProps) => {
   }
 
   return (
-    <ModalPortal>
-      <CommonModal className="addGroupModal" onClick={onClose}>
-        {isRequesting && <Loading text="저장중입니다. 잠시만 기다려주세요!" />}
-        <ArtistModalTitle>
-          아티스트 {type === 'add' ? '등록' : '수정'}하기
-        </ArtistModalTitle>
-        <ArtistModalCloseButton type="button" onClick={onClose}>
-          <img src={closeIcon} />
-        </ArtistModalCloseButton>
-        <TypeTitle>아티스트 타입을 선택해주세요.</TypeTitle>
-        <TypeWrapper>{content}</TypeWrapper>
-        <ArtistImageNameWrapper>
-          <ArtistImagePreview htmlFor="artistImage" previewimage={previewImage}>
-            <img src={photoIcon} alt="아티스트 이미지 선택" />
-          </ArtistImagePreview>
-          <StyledInput
-            type="file"
-            id="artistImage"
-            accept="image/png, image/jpeg"
-            onChange={onChangeArtistImage}
+    <CommonModal className="addGroupModal" onClick={onClose}>
+      {isRequesting && <Loading text="저장중입니다. 잠시만 기다려주세요!" />}
+      <ArtistModalTitle>
+        아티스트 {type === 'add' ? '등록' : '수정'}하기
+      </ArtistModalTitle>
+      <ArtistModalCloseButton type="button" onClick={onClose}>
+        <img src={closeIcon} />
+      </ArtistModalCloseButton>
+      <TypeTitle>아티스트 타입을 선택해주세요.</TypeTitle>
+      <TypeWrapper>{content}</TypeWrapper>
+      <ArtistImageNameWrapper>
+        <ArtistImagePreview htmlFor="artistImage" previewimage={previewImage}>
+          <img src={photoIcon} alt="아티스트 이미지 선택" />
+        </ArtistImagePreview>
+        <StyledInput
+          type="file"
+          id="artistImage"
+          accept="image/png, image/jpeg"
+          onChange={onChangeArtistImage}
+        />
+        <ArtistInfoWrapper>
+          <GroupSortDropdown
+            className="groupSortdrop"
+            sortButtonRef={sortButtonRef}
+            clicked={SortModal}
+            setClicked={setSortModal}
+            sortOptions={sortOption}
+            selectedText={dropdownText}
+            setSelectedText={setDropdownText}
+            setId={setGroupId}
           />
-          <ArtistInfoWrapper>
-            <GroupSortDropdown
-              className="groupSortdrop"
-              sortButtonRef={sortButtonRef}
-              clicked={SortModal}
-              setClicked={setSortModal}
-              sortOptions={sortOption}
-              selectedText={dropdownText}
-              setSelectedText={setDropdownText}
-              setId={setGroupId}
-            />
-            <NameLabel htmlFor="artistName">
-              아티스트 이름을 {type === 'add' ? '입력' : '수정'}해 주세요.
-            </NameLabel>
-            <ArtistNameInput
-              type="text"
-              id="artistName"
-              value={artistName}
-              onChange={onChangeArtistName}
-              placeholder="아티스트 이름"
-            />
-          </ArtistInfoWrapper>
-        </ArtistImageNameWrapper>
-        <ArtistSubmitButton type="button" onClick={onClickSaveBtnHandler}>
-          완료
-        </ArtistSubmitButton>
-      </CommonModal>
-    </ModalPortal>
+          <NameLabel htmlFor="artistName">
+            아티스트 이름을 {type === 'add' ? '입력' : '수정'}해 주세요.
+          </NameLabel>
+          <ArtistNameInput
+            type="text"
+            id="artistName"
+            value={artistName}
+            onChange={onChangeArtistName}
+            placeholder="아티스트 이름"
+          />
+        </ArtistInfoWrapper>
+      </ArtistImageNameWrapper>
+      <ArtistSubmitButton type="button" onClick={onClickSaveBtnHandler}>
+        완료
+      </ArtistSubmitButton>
+    </CommonModal>
   );
 };
 

--- a/src/features/artists/modals/ArtistModal.tsx
+++ b/src/features/artists/modals/ArtistModal.tsx
@@ -3,11 +3,16 @@ import { useSelector } from 'react-redux';
 
 import closeIcon from '../../../assets/close.svg';
 import photoIcon from '../../../assets/photo.svg';
+import defaultImage from '../../../assets/user-profile.svg';
 import Loading from '../../../components/Loading';
 import CommonModal from '../../../components/modal/CommonModal';
 import TypeButton from '../../../components/modal/TypeButton';
 import useImageProcessing from '../../../hooks/useImageProcessing';
-import { ArtistType } from '../../../types/artistsType';
+import {
+  ArtistType,
+  ArtistDataType,
+  EditArtistDataType,
+} from '../../../types/artistsType';
 import { performApiAction } from '../../../utils/apiHelpers';
 import { ModalProps } from '../../modal/modalsSlice';
 import {
@@ -38,9 +43,6 @@ export type sortOptionsType = {
   id: number;
   handler?: () => void;
 };
-
-const testImg =
-  'https://images.unsplash.com/photo-1567880905822-56f8e06fe630?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=735&q=80';
 
 const ArtistModal = ({ type, onClose }: ModalProps) => {
   const baseURL = process.env.REACT_APP_BASE_URL;
@@ -84,7 +86,7 @@ const ArtistModal = ({ type, onClose }: ModalProps) => {
       setArtistName(editData.name);
       editData.groupName && setDropdownText(editData.groupName);
       if (editData.image === '/images/null') {
-        setPreviewImage(testImg);
+        setPreviewImage(defaultImage);
         return;
       }
       setSavedImagefile(editData.image.slice(8));
@@ -156,7 +158,12 @@ const ArtistModal = ({ type, onClose }: ModalProps) => {
 
         const successMessage = `아티스트의 정보가 정상적으로 추가되었습니다`;
 
-        await performApiAction(data, addArtist, onClose, successMessage);
+        await performApiAction<ArtistDataType>(
+          data,
+          addArtist,
+          onClose,
+          successMessage
+        );
       } else if (type === 'edit' && filename) {
         const data = {
           artistTypeId: artistType,
@@ -167,7 +174,7 @@ const ArtistModal = ({ type, onClose }: ModalProps) => {
 
         const successMessage = `아티스트의 정보가 정상적으로 수정되었습니다`;
 
-        await performApiAction(
+        await performApiAction<EditArtistDataType>(
           { artistId: editData.id, artistValue: data },
           editArtist,
           onClose,

--- a/src/features/artists/modals/ArtistSelectModal.tsx
+++ b/src/features/artists/modals/ArtistSelectModal.tsx
@@ -2,9 +2,7 @@ import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
 
-import CommonModal, {
-  ModalPortal,
-} from '../../../components/modal/CommonModal';
+import CommonModal from '../../../components/modal/CommonModal';
 import useDebounce from '../../../hooks/useDebounce';
 import useInput from '../../../hooks/useInput';
 import useScroll from '../../../hooks/useScroll';
@@ -128,23 +126,21 @@ const ArtistSelectModal = ({ onClose }: ModalProps) => {
   };
 
   return (
-    <ModalPortal>
-      <CommonModal width="1046" onClick={onClose}>
-        <ModalCloseButton onClick={onClose} />
-        <ModalTitle>아티스트 선택하기</ModalTitle>
-        <AritstSelectSection>
-          <ArtistSearchInput
-            onChange={onSearchInputChange}
-            value={search.value}
-            onReset={onSearchInputReset}
-          />
-          <ArtistListSection ref={ulRef}>{content}</ArtistListSection>
-        </AritstSelectSection>
-        <DoneButton type="button" onClick={SaveArtistIds}>
-          완료
-        </DoneButton>
-      </CommonModal>
-    </ModalPortal>
+    <CommonModal width="1046" onClick={onClose}>
+      <ModalCloseButton onClick={onClose} />
+      <ModalTitle>아티스트 선택하기</ModalTitle>
+      <AritstSelectSection>
+        <ArtistSearchInput
+          onChange={onSearchInputChange}
+          value={search.value}
+          onReset={onSearchInputReset}
+        />
+        <ArtistListSection ref={ulRef}>{content}</ArtistListSection>
+      </AritstSelectSection>
+      <DoneButton type="button" onClick={SaveArtistIds}>
+        완료
+      </DoneButton>
+    </CommonModal>
   );
 };
 

--- a/src/features/artists/modals/ArtistTypeModal.tsx
+++ b/src/features/artists/modals/ArtistTypeModal.tsx
@@ -51,7 +51,7 @@ const ArtistTypeModal = ({ type, onClose }: ModalProps) => {
     setTypeName(e.target.value);
   };
 
-  const onClickTypeBtn = async () => {
+  const onClickSaveBtn = async () => {
     try {
       setIsRequesting(true);
 
@@ -153,7 +153,7 @@ const ArtistTypeModal = ({ type, onClose }: ModalProps) => {
         onChange={onChangeTypeName}
         placeholder="직접 입력"
       />
-      <SubmitButton type="button" onClick={onClickTypeBtn}>
+      <SubmitButton type="button" onClick={onClickSaveBtn}>
         완료
       </SubmitButton>
     </CommonModal>

--- a/src/features/artists/modals/ArtistTypeModal.tsx
+++ b/src/features/artists/modals/ArtistTypeModal.tsx
@@ -7,7 +7,6 @@ import CommonModal from '../../../components/modal/CommonModal';
 import TypeButton from '../../../components/modal/TypeButton';
 import {
   ArtisttypeType,
-  AritsttypeAddType,
 } from '../../../types/artisttypeType';
 import { performApiAction } from '../../../utils/apiHelpers';
 import {
@@ -64,24 +63,14 @@ const ArtistTypeModal = ({ type, onClose }: ModalProps) => {
           type: typeName,
         };
         const successMessage = '아티스트 타입이 정상적으로 추가되었습니다.';
-        await performApiAction<AritsttypeAddType>(
-          data,
-          addArtistType,
-          onClose,
-          successMessage
-        );
+        await performApiAction(data, addArtistType, onClose, successMessage);
       } else if (type === 'edit') {
         const data = {
           id: editData.id,
           type: typeName,
         };
         const successMessage = '아티스트 타입이 정상적으로 수정되었습니다.';
-        await performApiAction<ArtisttypeType>(
-          data,
-          editArtistType,
-          onClose,
-          successMessage
-        );
+        await performApiAction(data, editArtistType, onClose, successMessage);
       }
     } catch (error) {
       console.error(error);

--- a/src/features/artists/modals/ArtistTypeModal.tsx
+++ b/src/features/artists/modals/ArtistTypeModal.tsx
@@ -2,9 +2,7 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import closeIcon from '../../../assets/close.svg';
-import CommonModal, {
-  ModalPortal,
-} from '../../../components/modal/CommonModal';
+import CommonModal from '../../../components/modal/CommonModal';
 import TypeButton from '../../../components/modal/TypeButton';
 import {
   CategoryInput,
@@ -95,43 +93,41 @@ const ArtistTypeModal = ({ type, onClose }: ModalProps) => {
   }
 
   return (
-    <ModalPortal>
-      <CommonModal className="addGroupModal" onClick={onClose}>
-        <ModalTitle>
-          아티스트 타입 {type === 'add' ? '등록' : '수정'}하기
-        </ModalTitle>
-        <ModalCloseButton type="button" onClick={onClose}>
-          <img src={closeIcon} />
-        </ModalCloseButton>
-        <NameLabel htmlFor="artistName">
-          아티스트 타입을 {type === 'add' ? '입력' : '수정'}해 주세요.
-        </NameLabel>
-        <TypeWrapper>
-          {type === 'add' ? (
-            typeContents
-          ) : (
-            <TypeButton
-              data={{ id: editData.id }}
-              text={typeName}
-              selected={true}
-            />
-          )}
-        </TypeWrapper>
-        <CategoryInput
-          type="text"
-          id="artistName"
-          value={typeName}
-          onChange={onChangeTypeName}
-          placeholder="직접 입력"
-        />
-        <SubmitButton
-          type="button"
-          onClick={type === 'add' ? onClickAddTypeBtn : onClickEditBtn}
-        >
-          완료
-        </SubmitButton>
-      </CommonModal>
-    </ModalPortal>
+    <CommonModal className="addGroupModal" onClick={onClose}>
+      <ModalTitle>
+        아티스트 타입 {type === 'add' ? '등록' : '수정'}하기
+      </ModalTitle>
+      <ModalCloseButton type="button" onClick={onClose}>
+        <img src={closeIcon} />
+      </ModalCloseButton>
+      <NameLabel htmlFor="artistName">
+        아티스트 타입을 {type === 'add' ? '입력' : '수정'}해 주세요.
+      </NameLabel>
+      <TypeWrapper>
+        {type === 'add' ? (
+          typeContents
+        ) : (
+          <TypeButton
+            data={{ id: editData.id }}
+            text={typeName}
+            selected={true}
+          />
+        )}
+      </TypeWrapper>
+      <CategoryInput
+        type="text"
+        id="artistName"
+        value={typeName}
+        onChange={onChangeTypeName}
+        placeholder="직접 입력"
+      />
+      <SubmitButton
+        type="button"
+        onClick={type === 'add' ? onClickAddTypeBtn : onClickEditBtn}
+      >
+        완료
+      </SubmitButton>
+    </CommonModal>
   );
 };
 

--- a/src/features/artists/modals/ArtistTypeModal.tsx
+++ b/src/features/artists/modals/ArtistTypeModal.tsx
@@ -125,7 +125,7 @@ const ArtistTypeModal = ({ type, onClose }: ModalProps) => {
 
   return (
     <CommonModal className="addGroupModal" onClick={onClose}>
-      {isRequesting && <Loading text="저장중입니다. 잠시만 기다려주세요." />}
+      {isRequesting && <Loading />}
       <ModalTitle>
         아티스트 타입 {type === 'add' ? '등록' : '수정'}하기
       </ModalTitle>

--- a/src/features/artists/modals/ArtistTypeModal.tsx
+++ b/src/features/artists/modals/ArtistTypeModal.tsx
@@ -5,9 +5,7 @@ import closeIcon from '../../../assets/close.svg';
 import Loading from '../../../components/Loading';
 import CommonModal from '../../../components/modal/CommonModal';
 import TypeButton from '../../../components/modal/TypeButton';
-import {
-  ArtisttypeType,
-} from '../../../types/artisttypeType';
+import { ArtisttypeType } from '../../../types/artisttypeType';
 import { performApiAction } from '../../../utils/apiHelpers';
 import {
   CategoryInput,

--- a/src/features/artists/modals/EventArtistModal.tsx
+++ b/src/features/artists/modals/EventArtistModal.tsx
@@ -2,9 +2,7 @@ import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import ArtistListItem from '../../../components/ArtistListItem';
-import CommonModal, {
-  ModalPortal,
-} from '../../../components/modal/CommonModal';
+import CommonModal from '../../../components/modal/CommonModal';
 import useDebounce from '../../../hooks/useDebounce';
 import useInput from '../../../hooks/useInput';
 import useScroll from '../../../hooks/useScroll';
@@ -131,56 +129,54 @@ const EventArtistModal = ({ onClose }: ModalProps) => {
   };
 
   return (
-    <ModalPortal>
-      <CommonModal width="1156" onClick={onClose}>
-        <ModalCloseButton type="button" onClick={onClose} />
-        <S.Wrapper>
-          <S.LeftSection>
-            <S.CurrentArtist src={currentImage} />
-            <S.TextBox>검색된 최애 아티스트명</S.TextBox>
-            <S.ArtistNameText>
-              {currentArtist && currentArtist.name}
-            </S.ArtistNameText>
-            <S.ArtistTypeWrapper>
-              {types &&
-                types.map((type) => (
-                  <S.ArtistTypeButton
-                    type="button"
-                    key={type.id}
-                    onClick={() => handleTypeButton(type.id)}
-                  >
-                    {type.type}
-                  </S.ArtistTypeButton>
-                ))}
-              <S.ArtistTypeButton
-                type="button"
-                onClick={() => handleTypeButton(null)}
-              >
-                reset
-              </S.ArtistTypeButton>
-            </S.ArtistTypeWrapper>
-            <S.ButtonWrapper>
-              <S.SubmitButton type="button" onClick={handleOkButton}>
-                확인
-              </S.SubmitButton>
-            </S.ButtonWrapper>
-          </S.LeftSection>
-          <S.RightSection>
-            <S.Title>아티스트 검색하기</S.Title>
-            <S.GroupSelectSection>
-              <ArtistSearchInput
-                value={search.value}
-                onChange={onSearchInputChange}
-                onReset={onSearchInputReset}
-              />
-              <S.ArtistListWrapper ref={targetRef}>
-                <S.ArtistListSection>{content}</S.ArtistListSection>
-              </S.ArtistListWrapper>
-            </S.GroupSelectSection>
-          </S.RightSection>
-        </S.Wrapper>
-      </CommonModal>
-    </ModalPortal>
+    <CommonModal width="1156" onClick={onClose}>
+      <ModalCloseButton type="button" onClick={onClose} />
+      <S.Wrapper>
+        <S.LeftSection>
+          <S.CurrentArtist src={currentImage} />
+          <S.TextBox>검색된 최애 아티스트명</S.TextBox>
+          <S.ArtistNameText>
+            {currentArtist && currentArtist.name}
+          </S.ArtistNameText>
+          <S.ArtistTypeWrapper>
+            {types &&
+              types.map((type) => (
+                <S.ArtistTypeButton
+                  type="button"
+                  key={type.id}
+                  onClick={() => handleTypeButton(type.id)}
+                >
+                  {type.type}
+                </S.ArtistTypeButton>
+              ))}
+            <S.ArtistTypeButton
+              type="button"
+              onClick={() => handleTypeButton(null)}
+            >
+              reset
+            </S.ArtistTypeButton>
+          </S.ArtistTypeWrapper>
+          <S.ButtonWrapper>
+            <S.SubmitButton type="button" onClick={handleOkButton}>
+              확인
+            </S.SubmitButton>
+          </S.ButtonWrapper>
+        </S.LeftSection>
+        <S.RightSection>
+          <S.Title>아티스트 검색하기</S.Title>
+          <S.GroupSelectSection>
+            <ArtistSearchInput
+              value={search.value}
+              onChange={onSearchInputChange}
+              onReset={onSearchInputReset}
+            />
+            <S.ArtistListWrapper ref={targetRef}>
+              <S.ArtistListSection>{content}</S.ArtistListSection>
+            </S.ArtistListWrapper>
+          </S.GroupSelectSection>
+        </S.RightSection>
+      </S.Wrapper>
+    </CommonModal>
   );
 };
 

--- a/src/features/artists/modals/GroupModal.tsx
+++ b/src/features/artists/modals/GroupModal.tsx
@@ -39,7 +39,7 @@ const GroupModal = ({ type, onClose }: ModalProps) => {
   // const [addNewImage] = useAddImageMutation({});
   const [addGroup] = useAddArtistsMutation();
   const [editGroup] = useEditArtistsMutation();
-  const { uploadImageToServer } = useImageProcessing();
+  const { ImageProcessing } = useImageProcessing();
   const editData = useSelector(selectEditArtistSlice);
 
   useEffect(() => {
@@ -79,7 +79,11 @@ const GroupModal = ({ type, onClose }: ModalProps) => {
         alert('그룹아티스트의 사진을 업로드 해주세요.');
         throw new Error('Invalid Group-Artist Picture');
       }
-      const filename = await processImage();
+
+      const filename = await ImageProcessing({
+        newImage: groupImage,
+        savedImage: savedImagefile,
+      });
 
       if (type === 'add') {
         filename && onSaveGroupInfoHandler(filename);
@@ -90,15 +94,6 @@ const GroupModal = ({ type, onClose }: ModalProps) => {
       console.error(error);
     } finally {
       setIsRequesting(false);
-    }
-  };
-
-  const processImage = async () => {
-    if (groupImage) {
-      const uploadImage = await uploadImageToServer(groupImage);
-      return uploadImage;
-    } else if (savedImagefile) {
-      return savedImagefile;
     }
   };
 

--- a/src/features/artists/modals/GroupModal.tsx
+++ b/src/features/artists/modals/GroupModal.tsx
@@ -4,9 +4,7 @@ import { useSelector } from 'react-redux';
 import closeIcon from '../../../assets/close.svg';
 import photoIcon from '../../../assets/photo.svg';
 import Loading from '../../../components/Loading';
-import CommonModal, {
-  ModalPortal,
-} from '../../../components/modal/CommonModal';
+import CommonModal from '../../../components/modal/CommonModal';
 import useImageProcessing from '../../../hooks/useImageProcessing';
 import handleErrorResponse from '../../../utils/handleErrorResponse';
 import { ModalProps } from '../../modal/modalsSlice';
@@ -160,41 +158,39 @@ const GroupModal = ({ type, onClose }: ModalProps) => {
   };
 
   return (
-    <ModalPortal>
-      <CommonModal className="addGroupModal" onClick={onClose}>
-        {isRequesting && <Loading text="저장중입니다. 잠시만 기다려주세요." />}
-        <ModalTitle>그룹 {type === 'add' ? '등록' : '수정'}하기</ModalTitle>
-        <ModalCloseButton type="button" onClick={onClose}>
-          <img src={closeIcon} />
-        </ModalCloseButton>
-        <ImageNameWrapper>
-          <ImagePreview htmlFor="artistImage" previewimage={previewImage}>
-            <img src={photoIcon} alt="그룹 이미지 선택" />
-          </ImagePreview>
-          <StyledInput
-            type="file"
-            id="artistImage"
-            accept="image/png, image/jpeg"
-            onChange={onChangeGroupImage}
+    <CommonModal className="addGroupModal" onClick={onClose}>
+      {isRequesting && <Loading text="저장중입니다. 잠시만 기다려주세요." />}
+      <ModalTitle>그룹 {type === 'add' ? '등록' : '수정'}하기</ModalTitle>
+      <ModalCloseButton type="button" onClick={onClose}>
+        <img src={closeIcon} />
+      </ModalCloseButton>
+      <ImageNameWrapper>
+        <ImagePreview htmlFor="artistImage" previewimage={previewImage}>
+          <img src={photoIcon} alt="그룹 이미지 선택" />
+        </ImagePreview>
+        <StyledInput
+          type="file"
+          id="artistImage"
+          accept="image/png, image/jpeg"
+          onChange={onChangeGroupImage}
+        />
+        <NameWrapper>
+          <NameLabel htmlFor="artistName">
+            그룹 이름을 {type === 'add' ? '입력' : '수정'}해 주세요.
+          </NameLabel>
+          <NameInput
+            type="text"
+            id="artistName"
+            value={groupName}
+            onChange={onChangeGroupName}
+            placeholder="그룹 이름"
           />
-          <NameWrapper>
-            <NameLabel htmlFor="artistName">
-              그룹 이름을 {type === 'add' ? '입력' : '수정'}해 주세요.
-            </NameLabel>
-            <NameInput
-              type="text"
-              id="artistName"
-              value={groupName}
-              onChange={onChangeGroupName}
-              placeholder="그룹 이름"
-            />
-          </NameWrapper>
-        </ImageNameWrapper>
-        <SubmitButton type="button" onClick={onClickSaveBtnHandler}>
-          완료
-        </SubmitButton>
-      </CommonModal>
-    </ModalPortal>
+        </NameWrapper>
+      </ImageNameWrapper>
+      <SubmitButton type="button" onClick={onClickSaveBtnHandler}>
+        완료
+      </SubmitButton>
+    </CommonModal>
   );
 };
 

--- a/src/features/artists/modals/GroupModal.tsx
+++ b/src/features/artists/modals/GroupModal.tsx
@@ -71,13 +71,11 @@ const GroupModal = ({ type, onClose }: ModalProps) => {
       setIsRequesting(true);
 
       if (!groupName) {
-        setIsRequesting(false);
         alert('그룹아티스트의 이름을 입력해주세요.');
         throw new Error('Invalid Group-Artist name');
       }
 
       if (!groupImage && !savedImagefile) {
-        setIsRequesting(false);
         alert('그룹아티스트의 사진을 업로드 해주세요.');
         throw new Error('Invalid Group-Artist Picture');
       }
@@ -90,6 +88,8 @@ const GroupModal = ({ type, onClose }: ModalProps) => {
       }
     } catch (error) {
       console.error(error);
+    } finally {
+      setIsRequesting(false);
     }
   };
 
@@ -115,7 +115,6 @@ const GroupModal = ({ type, onClose }: ModalProps) => {
       };
 
       const res = await addGroup(groupData);
-      setIsRequesting(false);
 
       if ('data' in res) {
         alert('그룹아티스트의 정보가 정상적으로 추가되었습니다');
@@ -144,7 +143,6 @@ const GroupModal = ({ type, onClose }: ModalProps) => {
         artistId: editData.id,
         artistValue: groupData,
       });
-      setIsRequesting(false);
 
       if ('data' in res) {
         alert('그룹아티스트의 정보가 정상적으로 수정되었습니다');

--- a/src/features/artists/modals/GroupModal.tsx
+++ b/src/features/artists/modals/GroupModal.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import closeIcon from '../../../assets/close.svg';
 import photoIcon from '../../../assets/photo.svg';
+import defaultImage from '../../../assets/user-profile.svg';
 import Loading from '../../../components/Loading';
 import CommonModal from '../../../components/modal/CommonModal';
 import useImageProcessing from '../../../hooks/useImageProcessing';
@@ -26,9 +27,6 @@ import {
   SubmitButton,
 } from './GroupModalStyle';
 
-const testImg =
-  'https://images.unsplash.com/photo-1567880905822-56f8e06fe630?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=735&q=80';
-
 const GroupModal = ({ type, onClose }: ModalProps) => {
   const baseURL = process.env.REACT_APP_BASE_URL;
   const [groupImage, setGroupImage] = useState<File>(); //File 자체
@@ -45,7 +43,7 @@ const GroupModal = ({ type, onClose }: ModalProps) => {
     if (type === 'edit') {
       setGroupName(editData.name);
       if (editData.image === '/images/null') {
-        setPreviewImage(testImg);
+        setPreviewImage(defaultImage);
         return;
       }
       setSavedImagefile(editData.image.slice(8));

--- a/src/features/artists/modals/GroupModal.tsx
+++ b/src/features/artists/modals/GroupModal.tsx
@@ -6,7 +6,8 @@ import photoIcon from '../../../assets/photo.svg';
 import Loading from '../../../components/Loading';
 import CommonModal from '../../../components/modal/CommonModal';
 import useImageProcessing from '../../../hooks/useImageProcessing';
-import handleErrorResponse from '../../../utils/handleErrorResponse';
+import { ArtistDataType, EditArtistDataType } from '../../../types/artistsType';
+import { performApiAction } from '../../../utils/apiHelpers';
 import { ModalProps } from '../../modal/modalsSlice';
 import {
   useAddArtistsMutation,
@@ -36,7 +37,6 @@ const GroupModal = ({ type, onClose }: ModalProps) => {
   const [savedImagefile, setSavedImagefile] = useState<string>(''); // 저장된 이미지의 filename
   const [groupName, setGroupName] = useState<string | undefined>(undefined);
   const [isRequesting, setIsRequesting] = useState(false);
-  // const [addNewImage] = useAddImageMutation({});
   const [addGroup] = useAddArtistsMutation();
   const [editGroup] = useEditArtistsMutation();
   const { ImageProcessing } = useImageProcessing();
@@ -85,68 +85,42 @@ const GroupModal = ({ type, onClose }: ModalProps) => {
         savedImage: savedImagefile,
       });
 
-      if (type === 'add') {
-        filename && onSaveGroupInfoHandler(filename);
-      } else if (type === 'edit') {
-        filename && onEditGroupInfoHandler(filename);
+      if (type === 'add' && filename) {
+        const data = {
+          artistTypeId: 1,
+          name: groupName,
+          image: filename,
+        };
+        const successMessage =
+          '그룹 아티스트의 정보가 정상적으로 추가되었습니다.';
+        performApiAction<ArtistDataType>(
+          data,
+          addGroup,
+          onClose,
+          successMessage
+        );
+      } else if (type === 'edit' && filename) {
+        const data = {
+          artistTypeId: 1,
+          name: groupName,
+          image: filename,
+        };
+        const successMessage =
+          '그룹 아티스트의 정보가 정상적으로 수정되었습니다.';
+        performApiAction<EditArtistDataType>(
+          {
+            artistId: editData.id,
+            artistValue: data,
+          },
+          editGroup,
+          onClose,
+          successMessage
+        );
       }
     } catch (error) {
       console.error(error);
     } finally {
       setIsRequesting(false);
-    }
-  };
-
-  const onSaveGroupInfoHandler = async (filename: string) => {
-    try {
-      if (!groupName) {
-        throw new Error('Invalid name');
-      }
-
-      const groupData = {
-        artistTypeId: 1,
-        name: groupName,
-        image: filename,
-      };
-
-      const res = await addGroup(groupData);
-
-      if ('data' in res) {
-        alert('그룹아티스트의 정보가 정상적으로 추가되었습니다');
-        onClose();
-      } else if ('error' in res) {
-        handleErrorResponse(res.error);
-      }
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  const onEditGroupInfoHandler = async (filename: string) => {
-    try {
-      if (!groupName) {
-        throw new Error('Invalid artist name');
-      }
-
-      const groupData = {
-        artistTypeId: 1,
-        name: groupName,
-        image: filename,
-      };
-
-      const res = await editGroup({
-        artistId: editData.id,
-        artistValue: groupData,
-      });
-
-      if ('data' in res) {
-        alert('그룹아티스트의 정보가 정상적으로 수정되었습니다');
-        onClose();
-      } else if ('error' in res) {
-        handleErrorResponse(res.error);
-      }
-    } catch (error) {
-      console.error(error);
     }
   };
 

--- a/src/features/artists/modals/GroupModal.tsx
+++ b/src/features/artists/modals/GroupModal.tsx
@@ -157,7 +157,7 @@ const GroupModal = ({ type, onClose }: ModalProps) => {
 
   return (
     <CommonModal className="addGroupModal" onClick={onClose}>
-      {isRequesting && <Loading text="저장중입니다. 잠시만 기다려주세요." />}
+      {isRequesting && <Loading />}
       <ModalTitle>그룹 {type === 'add' ? '등록' : '수정'}하기</ModalTitle>
       <ModalCloseButton type="button" onClick={onClose}>
         <img src={closeIcon} />

--- a/src/features/artists/modals/GroupModal.tsx
+++ b/src/features/artists/modals/GroupModal.tsx
@@ -6,7 +6,6 @@ import photoIcon from '../../../assets/photo.svg';
 import Loading from '../../../components/Loading';
 import CommonModal from '../../../components/modal/CommonModal';
 import useImageProcessing from '../../../hooks/useImageProcessing';
-import { ArtistDataType, EditArtistDataType } from '../../../types/artistsType';
 import { performApiAction } from '../../../utils/apiHelpers';
 import { ModalProps } from '../../modal/modalsSlice';
 import {
@@ -93,12 +92,7 @@ const GroupModal = ({ type, onClose }: ModalProps) => {
         };
         const successMessage =
           '그룹 아티스트의 정보가 정상적으로 추가되었습니다.';
-        performApiAction<ArtistDataType>(
-          data,
-          addGroup,
-          onClose,
-          successMessage
-        );
+        performApiAction(data, addGroup, onClose, successMessage);
       } else if (type === 'edit' && filename) {
         const data = {
           artistTypeId: 1,
@@ -107,7 +101,7 @@ const GroupModal = ({ type, onClose }: ModalProps) => {
         };
         const successMessage =
           '그룹 아티스트의 정보가 정상적으로 수정되었습니다.';
-        performApiAction<EditArtistDataType>(
+        performApiAction(
           {
             artistId: editData.id,
             artistValue: data,

--- a/src/features/artists/services/artistsApiSlice.ts
+++ b/src/features/artists/services/artistsApiSlice.ts
@@ -1,5 +1,5 @@
 import { apiSlice } from '../../../app/api/apiSlice';
-import { ArtistValue, ArtistsData } from '../../../types/artistsType';
+import { ArtistDataType, ArtistsRawDataType } from '../../../types/artistsType';
 import { Artist } from '../../../types/eventService';
 
 const accessToken = window.localStorage.getItem('admin');
@@ -43,7 +43,7 @@ export const artistsApiSlice = apiSlice.injectEndpoints({
           method: 'GET',
         };
       },
-      transformResponse: (response: ArtistsData) => {
+      transformResponse: (response: ArtistsRawDataType) => {
         const content = response.content;
         const isLast = response.last;
         return { content, isLast };
@@ -63,7 +63,7 @@ export const artistsApiSlice = apiSlice.injectEndpoints({
       providesTags: ['Artists'],
     }),
     addArtists: builder.mutation({
-      query: (artistValue: ArtistValue) => ({
+      query: (artistValue: ArtistDataType) => ({
         url: '/artists',
         method: 'POST',
         headers: {
@@ -79,7 +79,7 @@ export const artistsApiSlice = apiSlice.injectEndpoints({
         artistValue,
       }: {
         artistId: number;
-        artistValue: ArtistValue;
+        artistValue: ArtistDataType;
       }) => ({
         url: `/artists/${artistId}`,
         method: 'PUT',

--- a/src/features/artists/services/artistsTypeApiSlice.ts
+++ b/src/features/artists/services/artistsTypeApiSlice.ts
@@ -1,14 +1,17 @@
 import { apiSlice } from '../../../app/api/apiSlice';
-import { ArtistType } from '../../../types/artistsType';
+import {
+  ArtisttypeType,
+  AritsttypeAddType,
+} from '../../../types/artisttypeType';
 
 export const artistsTypeApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
-    getArtistsType: builder.query<ArtistType[], void>({
+    getArtistsType: builder.query<ArtisttypeType[], void>({
       query: () => '/artists/types',
       providesTags: ['ArtistType'],
     }),
-    addArtistsType: builder.mutation({
-      query: (type: string) => ({
+    addArtistsType: builder.mutation<any, AritsttypeAddType>({
+      query: ({ type }) => ({
         url: '/artists/types',
         method: 'POST',
         body: { type },

--- a/src/features/bookmarks/modals/BookmarkFolderModal.tsx
+++ b/src/features/bookmarks/modals/BookmarkFolderModal.tsx
@@ -148,7 +148,7 @@ const BookmarkFolderModal = ({ type, onClose }: ModalProps) => {
 
   return (
     <CommonModal onClick={onClose} width="860">
-      {isRequesting && <Loading text="저장중입니다. 잠시만 기다려주세요." />}
+      {isRequesting && <Loading />}
       <S.ModalContent>
         <S.ModalTitle>
           북마크 폴더 {type === 'add' ? '추가' : '수정'}하기

--- a/src/features/bookmarks/modals/BookmarkFolderModal.tsx
+++ b/src/features/bookmarks/modals/BookmarkFolderModal.tsx
@@ -5,9 +5,7 @@ import { useSelector } from 'react-redux';
 
 import closesmallicon from '../../../assets/close-small.svg';
 import closeicon from '../../../assets/close.svg';
-import CommonModal, {
-  ModalPortal,
-} from '../../../components/modal/CommonModal';
+import CommonModal from '../../../components/modal/CommonModal';
 import { emojiArray } from '../../../utils/EmojiArray';
 import { ModalProps } from '../../modal/modalsSlice';
 import {
@@ -113,90 +111,83 @@ const BookmarkFolderModal = ({ type, onClose }: ModalProps) => {
   };
 
   return (
-    <ModalPortal>
-      <CommonModal onClick={onClose} width="860">
-        <S.ModalContent>
-          <S.ModalTitle>
-            북마크 폴더 {type === 'add' ? '추가' : '수정'}하기
-          </S.ModalTitle>
-          <S.ModalCloseButton type="button" onClick={onClose}>
-            <img src={closeicon} />
-          </S.ModalCloseButton>
-          <S.FoldernameSection>
-            <S.FoldernameLabel>
-              북마크 폴더 이름을 {type === 'add' ? '입력' : '수정'}해 주세요.
-            </S.FoldernameLabel>
-            <S.FoldernameInput
-              type="text"
-              placeholder={
-                type === 'add' ? '북마크 폴더 이름' : '선택한 북마크 폴더 이름'
-              }
-              value={foldername}
-              onChange={onChangeFoldername}
-            />
-            <S.FoldernameDeleteBtn onClick={onDeleteCurrentFoldername}>
-              <img src={closesmallicon} />
-            </S.FoldernameDeleteBtn>
-          </S.FoldernameSection>
-          <S.FoldericonSection>
-            <S.IconSectionTitle>
-              폴더 아이콘을 선택해 주세요.
-            </S.IconSectionTitle>
-            <S.IconSelectSection>
-              <S.EmojiBox>
-                <S.EmojiLists>
-                  {emojiArray.map((emoji) => (
-                    <Emoji
-                      key={emoji.id}
-                      name={emoji.name}
-                      value={emoji.value}
-                      img={emoji.img}
-                      onChange={onSelectEmoji}
-                      isSelected={emoji.value === selectEmoji}
-                    />
-                  ))}
-                </S.EmojiLists>
-              </S.EmojiBox>
-              <S.EmojiPreviewFolderWrapper>
-                <S.StyledBookmarkFolder fill="#DEFCF9" />
-                <S.EmojiPreview img={selectEmoji}>
-                  <img
-                    src={
-                      emojiArray.find((emoji) => emoji.value === selectEmoji)
-                        ?.img
-                    }
+    <CommonModal onClick={onClose} width="860">
+      <S.ModalContent>
+        <S.ModalTitle>
+          북마크 폴더 {type === 'add' ? '추가' : '수정'}하기
+        </S.ModalTitle>
+        <S.ModalCloseButton type="button" onClick={onClose}>
+          <img src={closeicon} />
+        </S.ModalCloseButton>
+        <S.FoldernameSection>
+          <S.FoldernameLabel>
+            북마크 폴더 이름을 {type === 'add' ? '입력' : '수정'}해 주세요.
+          </S.FoldernameLabel>
+          <S.FoldernameInput
+            type="text"
+            placeholder={
+              type === 'add' ? '북마크 폴더 이름' : '선택한 북마크 폴더 이름'
+            }
+            value={foldername}
+            onChange={onChangeFoldername}
+          />
+          <S.FoldernameDeleteBtn onClick={onDeleteCurrentFoldername}>
+            <img src={closesmallicon} />
+          </S.FoldernameDeleteBtn>
+        </S.FoldernameSection>
+        <S.FoldericonSection>
+          <S.IconSectionTitle>폴더 아이콘을 선택해 주세요.</S.IconSectionTitle>
+          <S.IconSelectSection>
+            <S.EmojiBox>
+              <S.EmojiLists>
+                {emojiArray.map((emoji) => (
+                  <Emoji
+                    key={emoji.id}
+                    name={emoji.name}
+                    value={emoji.value}
+                    img={emoji.img}
+                    onChange={onSelectEmoji}
+                    isSelected={emoji.value === selectEmoji}
                   />
-                </S.EmojiPreview>
-                <S.Previewtext>미리보기</S.Previewtext>
-              </S.EmojiPreviewFolderWrapper>
-            </S.IconSelectSection>
-          </S.FoldericonSection>
-          <S.FolderColorSection>
-            <S.ColorSectionTitle>
-              폴더 컬러를 선택해 주세요.
-            </S.ColorSectionTitle>
-            <S.ColorSelectSection>
-              <S.ColorBox>
-                <Wheel
-                  color={hsva}
-                  onChange={(color) => setHsva({ ...hsva, ...color.hsva })}
+                ))}
+              </S.EmojiLists>
+            </S.EmojiBox>
+            <S.EmojiPreviewFolderWrapper>
+              <S.StyledBookmarkFolder fill="#DEFCF9" />
+              <S.EmojiPreview img={selectEmoji}>
+                <img
+                  src={
+                    emojiArray.find((emoji) => emoji.value === selectEmoji)?.img
+                  }
                 />
-              </S.ColorBox>
-              <S.ColorPreviewFolderWrapper>
-                <S.StyledBookmarkFolder fill={selectColor} />
-                <S.Previewtext>미리보기</S.Previewtext>
-              </S.ColorPreviewFolderWrapper>
-            </S.ColorSelectSection>
-          </S.FolderColorSection>
-          <S.AddNewFolderBtn
-            type="button"
-            onClick={type === 'add' ? onClickAddNewFolder : onClickEditFolder}
-          >
-            완료
-          </S.AddNewFolderBtn>
-        </S.ModalContent>
-      </CommonModal>
-    </ModalPortal>
+              </S.EmojiPreview>
+              <S.Previewtext>미리보기</S.Previewtext>
+            </S.EmojiPreviewFolderWrapper>
+          </S.IconSelectSection>
+        </S.FoldericonSection>
+        <S.FolderColorSection>
+          <S.ColorSectionTitle>폴더 컬러를 선택해 주세요.</S.ColorSectionTitle>
+          <S.ColorSelectSection>
+            <S.ColorBox>
+              <Wheel
+                color={hsva}
+                onChange={(color) => setHsva({ ...hsva, ...color.hsva })}
+              />
+            </S.ColorBox>
+            <S.ColorPreviewFolderWrapper>
+              <S.StyledBookmarkFolder fill={selectColor} />
+              <S.Previewtext>미리보기</S.Previewtext>
+            </S.ColorPreviewFolderWrapper>
+          </S.ColorSelectSection>
+        </S.FolderColorSection>
+        <S.AddNewFolderBtn
+          type="button"
+          onClick={type === 'add' ? onClickAddNewFolder : onClickEditFolder}
+        >
+          완료
+        </S.AddNewFolderBtn>
+      </S.ModalContent>
+    </CommonModal>
   );
 };
 

--- a/src/features/bookmarks/modals/BookmarkModal.tsx
+++ b/src/features/bookmarks/modals/BookmarkModal.tsx
@@ -2,10 +2,12 @@ import { useEffect, useState, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import closeIcon from '../../../assets/close.svg';
+import Loading from '../../../components/Loading';
 import CommonModal from '../../../components/modal/CommonModal';
 import useScroll from '../../../hooks/useScroll';
 import { BookmarkFolderType } from '../../../types/bookmarkFolderType';
 import { emojiArray } from '../../../utils/EmojiArray';
+import handleErrorResponse from '../../../utils/handleErrorResponse';
 import { ModalProps } from '../../modal/modalsSlice';
 import {
   useAddBookmarkEventMutation,
@@ -71,6 +73,7 @@ const BookmarkModal = ({ type, onClose }: ModalProps) => {
   const [bookmarkFolders, setBookmarkFolders] = useState<BookmarkFolderType[]>(
     []
   );
+  const [isRequesting, setIsRequesting] = useState(false);
   const [addBookmark] = useAddBookmarkEventMutation();
   const [editBookmarkFolder] = useEditBookmarkEventFolderMutation();
 
@@ -125,59 +128,63 @@ const BookmarkModal = ({ type, onClose }: ModalProps) => {
     setPage: setBookmarkFoldersPage,
   });
 
-  const onClickSubmit = async () => {
-    if (selectedFolder === null) {
-      alert('북마크 폴더를 선택해주세요.');
-      return;
-    }
-    const res = await addBookmark({ id: eventId, folderId: selectedFolder });
+  const onClickSaveBtn = async () => {
+    try {
+      setIsRequesting(true);
 
-    if ('data' in res) {
-      dispatch(addBookmarkInfo({ eventId, isBookmark: true }));
-      onClose();
-    } else if ('error' in res) {
-      const error = res.error;
-      if ('data' in error) {
-        const data = error.data;
-        if (data !== null && typeof data === 'object' && 'message' in data) {
-          const errorMessage = data.message;
-          alert(errorMessage);
-          return;
-        }
+      if (!selectedFolder) {
+        alert('북마크 폴더를 선택해주세요.');
+        throw new Error('Invalid Bookmark Folder');
       }
-      alert('잠시 후에 다시 시도해주세요.');
+      if (type === 'add') {
+        await onSaveBookmarkHandler();
+      } else if (type === 'edit') {
+        await onEditBookmarkHandler();
+      }
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsRequesting(false);
     }
   };
 
-  const onClickEdit = async () => {
-    if (selectedFolder === null) {
-      alert('북마크 폴더를 선택해주세요.');
-      return;
+  const onSaveBookmarkHandler = async () => {
+    try {
+      const data = { id: eventId, folderId: selectedFolder };
+      const res = await addBookmark(data);
+
+      if ('data' in res) {
+        dispatch(addBookmarkInfo({ eventId, isBookmark: true })); //북마크 정보 즉각 업뎃하기 위해서
+        onClose();
+      } else if ('error' in res) {
+        handleErrorResponse(res.error);
+      }
+    } catch (error) {
+      console.error(error);
     }
-    const res = await editBookmarkFolder({
+  };
+
+  const onEditBookmarkHandler = async () => {
+    const data = {
       id: eventId,
       folderId: selectedFolder,
-    });
-
-    if ('data' in res) {
-      dispatch(addBookmarkInfo({ eventId, isBookmark: true }));
-      onClose();
-    } else if ('error' in res) {
-      const error = res.error;
-      if ('data' in error) {
-        const data = error.data;
-        if (data !== null && typeof data === 'object' && 'message' in data) {
-          const errorMessage = data.message;
-          alert(errorMessage);
-          return;
-        }
+    };
+    try {
+      const res = await editBookmarkFolder(data);
+      if ('data' in res) {
+        dispatch(addBookmarkInfo({ eventId, isBookmark: true }));
+        onClose();
+      } else if ('error' in res) {
+        handleErrorResponse(res.error);
       }
-      alert('잠시 후에 다시 시도해주세요.');
+    } catch (error) {
+      console.error(error);
     }
   };
 
   return (
     <CommonModal width="490" onClick={onClose}>
+      {isRequesting && <Loading />}
       <S.ModalTitle>
         {type === 'add' ? '북마크 추가하기' : '북마크 폴더 변경하기'}
       </S.ModalTitle>
@@ -193,10 +200,7 @@ const BookmarkModal = ({ type, onClose }: ModalProps) => {
           )}
         </S.FoldersLists>
       </S.FoldersContainer>
-      <S.SubmitButton
-        type="button"
-        onClick={type === 'add' ? onClickSubmit : onClickEdit}
-      >
+      <S.SubmitButton type="button" onClick={onClickSaveBtn}>
         완료
       </S.SubmitButton>
     </CommonModal>

--- a/src/features/bookmarks/modals/BookmarkModal.tsx
+++ b/src/features/bookmarks/modals/BookmarkModal.tsx
@@ -2,9 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import closeIcon from '../../../assets/close.svg';
-import CommonModal, {
-  ModalPortal,
-} from '../../../components/modal/CommonModal';
+import CommonModal from '../../../components/modal/CommonModal';
 import useScroll from '../../../hooks/useScroll';
 import { BookmarkFolderType } from '../../../types/bookmarkFolderType';
 import { emojiArray } from '../../../utils/EmojiArray';
@@ -179,31 +177,29 @@ const BookmarkModal = ({ type, onClose }: ModalProps) => {
   };
 
   return (
-    <ModalPortal>
-      <CommonModal width="490" onClick={onClose}>
-        <S.ModalTitle>
-          {type === 'add' ? '북마크 추가하기' : '북마크 폴더 변경하기'}
-        </S.ModalTitle>
-        <ModalCloseButton type="button" onClick={onClose}>
-          <img src={closeIcon} />
-        </ModalCloseButton>
-        <S.FoldersContainer>
-          <S.FoldersLists ref={targetRef}>
-            {numberOfFolders ? (
-              foldersContent
-            ) : (
-              <div>북마크 폴더가 없습니다.</div>
-            )}
-          </S.FoldersLists>
-        </S.FoldersContainer>
-        <S.SubmitButton
-          type="button"
-          onClick={type === 'add' ? onClickSubmit : onClickEdit}
-        >
-          완료
-        </S.SubmitButton>
-      </CommonModal>
-    </ModalPortal>
+    <CommonModal width="490" onClick={onClose}>
+      <S.ModalTitle>
+        {type === 'add' ? '북마크 추가하기' : '북마크 폴더 변경하기'}
+      </S.ModalTitle>
+      <ModalCloseButton type="button" onClick={onClose}>
+        <img src={closeIcon} />
+      </ModalCloseButton>
+      <S.FoldersContainer>
+        <S.FoldersLists ref={targetRef}>
+          {numberOfFolders ? (
+            foldersContent
+          ) : (
+            <div>북마크 폴더가 없습니다.</div>
+          )}
+        </S.FoldersLists>
+      </S.FoldersContainer>
+      <S.SubmitButton
+        type="button"
+        onClick={type === 'add' ? onClickSubmit : onClickEdit}
+      >
+        완료
+      </S.SubmitButton>
+    </CommonModal>
   );
 };
 

--- a/src/features/categories/modals/CategoryModal.tsx
+++ b/src/features/categories/modals/CategoryModal.tsx
@@ -2,9 +2,7 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import closeIcon from '../../../assets/close.svg';
-import CommonModal, {
-  ModalPortal,
-} from '../../../components/modal/CommonModal';
+import CommonModal from '../../../components/modal/CommonModal';
 import TypeButton from '../../../components/modal/TypeButton';
 import { ModalProps } from '../../modal/modalsSlice';
 import {
@@ -90,45 +88,43 @@ const CategoryModal = ({ type, onClose }: ModalProps) => {
   }
 
   return (
-    <ModalPortal>
-      <CommonModal className="addGroupModal" onClick={onClose}>
-        <CategoryModalTitle>
-          카테고리 {type === 'add' ? '등록' : '수정'}하기
-        </CategoryModalTitle>
-        <CategoryModalCloseButton type="button" onClick={onClose}>
-          <img src={closeIcon} />
-        </CategoryModalCloseButton>
-        <CategoryNameLabel htmlFor="artistName">
-          카테고리를 {type === 'add' ? '입력' : '수정'}해 주세요.
-        </CategoryNameLabel>
-        <TypeWrapper>
-          {type === 'add' ? (
-            typeContents
-          ) : (
-            <TypeButton
-              data={{ id: editData.id }}
-              text={editData.category}
-              selected={true}
-            />
-          )}
-        </TypeWrapper>
-        <CategoryInput
-          type="text"
-          id="artistName"
-          value={categoryName}
-          onChange={onChangeCategoryName}
-          placeholder="직접 입력"
-        />
-        <CategorySubmitButton
-          type="button"
-          onClick={
-            type === 'add' ? onClickAddCategoryBtn : onClickEditCategoryBtn
-          }
-        >
-          완료
-        </CategorySubmitButton>
-      </CommonModal>
-    </ModalPortal>
+    <CommonModal className="addGroupModal" onClick={onClose}>
+      <CategoryModalTitle>
+        카테고리 {type === 'add' ? '등록' : '수정'}하기
+      </CategoryModalTitle>
+      <CategoryModalCloseButton type="button" onClick={onClose}>
+        <img src={closeIcon} />
+      </CategoryModalCloseButton>
+      <CategoryNameLabel htmlFor="artistName">
+        카테고리를 {type === 'add' ? '입력' : '수정'}해 주세요.
+      </CategoryNameLabel>
+      <TypeWrapper>
+        {type === 'add' ? (
+          typeContents
+        ) : (
+          <TypeButton
+            data={{ id: editData.id }}
+            text={editData.category}
+            selected={true}
+          />
+        )}
+      </TypeWrapper>
+      <CategoryInput
+        type="text"
+        id="artistName"
+        value={categoryName}
+        onChange={onChangeCategoryName}
+        placeholder="직접 입력"
+      />
+      <CategorySubmitButton
+        type="button"
+        onClick={
+          type === 'add' ? onClickAddCategoryBtn : onClickEditCategoryBtn
+        }
+      >
+        완료
+      </CategorySubmitButton>
+    </CommonModal>
   );
 };
 

--- a/src/features/categories/modals/CategoryModal.tsx
+++ b/src/features/categories/modals/CategoryModal.tsx
@@ -5,7 +5,7 @@ import closeIcon from '../../../assets/close.svg';
 import Loading from '../../../components/Loading';
 import CommonModal from '../../../components/modal/CommonModal';
 import TypeButton from '../../../components/modal/TypeButton';
-import handleErrorResponse from '../../../utils/handleErrorResponse';
+import { performApiAction } from '../../../utils/apiHelpers';
 import { ModalProps } from '../../modal/modalsSlice';
 import {
   useGetEventCategoryQuery,
@@ -43,6 +43,10 @@ const CategoryModal = ({ type, onClose }: ModalProps) => {
     }
   }, [editData]);
 
+  useEffect(() => {
+    if (eventCategories) setCategoryContents(eventCategories);
+  }, [eventCategories]);
+
   const onChangeCategoryName = (e: React.ChangeEvent<HTMLInputElement>) => {
     setCategoryName(e.target.value);
   };
@@ -56,10 +60,23 @@ const CategoryModal = ({ type, onClose }: ModalProps) => {
         throw new Error('Invalid Category');
       }
 
-      if ((type = 'add')) {
-        await onSaveCategoryHandler();
-      } else if ((type = 'edit')) {
-        await onEditCategoryHandler();
+      if (type === 'add') {
+        const successMessage = '카테고리가 정상적으로 추가되었습니다.';
+
+        await performApiAction(
+          categoryName,
+          addNewCategory,
+          onClose,
+          successMessage
+        );
+      } else if (type === 'edit') {
+        const data = {
+          id: editData.id,
+          category: categoryName,
+        };
+        const successMessage = '카테고리가 정상적으로 수정되었습니다.';
+
+        await performApiAction(data, editCategory, onClose, successMessage);
       }
     } catch (error) {
       console.error(error);
@@ -67,44 +84,6 @@ const CategoryModal = ({ type, onClose }: ModalProps) => {
       setIsRequesting(false);
     }
   };
-
-  const onSaveCategoryHandler = async () => {
-    try {
-      const res = await addNewCategory(categoryName);
-      if ('data' in res) {
-        alert('카테고리가 정상적으로 추가되었습니다.');
-        onClose();
-      } else if ('error' in res) {
-        handleErrorResponse(res.error);
-      }
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  const onEditCategoryHandler = async () => {
-    try {
-      const data = {
-        id: editData.id,
-        category: categoryName,
-      };
-
-      const res = await editCategory(data);
-
-      if ('data' in res) {
-        alert('카테고리가 정상적으로 수정되었습니다.');
-        onClose();
-      } else if ('error' in res) {
-        handleErrorResponse(res.error);
-      }
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  useEffect(() => {
-    if (eventCategories) setCategoryContents(eventCategories);
-  }, [eventCategories]);
 
   let typeContents;
   if (categoryContents.length > 0) {

--- a/src/features/categories/modals/CategoryModal.tsx
+++ b/src/features/categories/modals/CategoryModal.tsx
@@ -120,7 +120,7 @@ const CategoryModal = ({ type, onClose }: ModalProps) => {
 
   return (
     <CommonModal className="addGroupModal" onClick={onClose}>
-      {isRequesting && <Loading text="저장중입니다. 잠시만 기다려주세요." />}
+      {isRequesting && <Loading />}
       <CategoryModalTitle>
         카테고리 {type === 'add' ? '등록' : '수정'}하기
       </CategoryModalTitle>

--- a/src/features/categories/modals/CategoryModal.tsx
+++ b/src/features/categories/modals/CategoryModal.tsx
@@ -111,7 +111,7 @@ const CategoryModal = ({ type, onClose }: ModalProps) => {
     typeContents = categoryContents.map((content) => (
       <TypeButton
         key={content.id}
-        data={content}
+        id={content.id}
         text={content.category}
         selected={true}
       />
@@ -135,7 +135,7 @@ const CategoryModal = ({ type, onClose }: ModalProps) => {
           typeContents
         ) : (
           <TypeButton
-            data={{ id: editData.id }}
+            id={editData.id}
             text={editData.category}
             selected={true}
           />

--- a/src/features/categories/modals/CategorySelectModal.tsx
+++ b/src/features/categories/modals/CategorySelectModal.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
 
 import CommonModal from '../../../components/modal/CommonModal';
+import { CategoryType } from '../../../types/categoryType';
 import {
   ModalCloseButton,
   DoneButton,
@@ -13,10 +14,7 @@ import {
   setCategory,
 } from '../../events/services/setEventElemetsSlice';
 import { ModalProps } from '../../modal/modalsSlice';
-import {
-  categoryType,
-  useGetEventCategoryQuery,
-} from '../services/categoryApiSlice';
+import { useGetEventCategoryQuery } from '../services/categoryApiSlice';
 
 import {
   CategoryModalTitle,
@@ -27,7 +25,7 @@ import {
 
 const CategorySelectModal = ({ onClose }: ModalProps) => {
   const dispatch = useDispatch();
-  const [categories, setCategories] = useState<categoryType[]>([]);
+  const [categories, setCategories] = useState<CategoryType[]>([]);
   const selectedCategories = useSelector(selectSelectedCategory);
   const [categoriesIds, setCategoriesIds] =
     useState<Category[]>(selectedCategories);

--- a/src/features/categories/modals/CategorySelectModal.tsx
+++ b/src/features/categories/modals/CategorySelectModal.tsx
@@ -2,9 +2,7 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
 
-import CommonModal, {
-  ModalPortal,
-} from '../../../components/modal/CommonModal';
+import CommonModal from '../../../components/modal/CommonModal';
 import {
   ModalCloseButton,
   DoneButton,
@@ -64,32 +62,30 @@ const CategorySelectModal = ({ onClose }: ModalProps) => {
   }, [categoryData]);
 
   return (
-    <ModalPortal>
-      <CommonModal width="1046px" onClick={onClose}>
-        <ModalCloseButton onClick={onClose} />
-        <CategoryModalTitle>카테고리 선택하기</CategoryModalTitle>
-        <CategorySelectSection>
-          <CategoryListSection>
-            {categories &&
-              categories.map((category) => (
-                <CategoryItem
-                  key={category.id}
-                  onClick={() => {
-                    onCategoryClick(category.id, category.category);
-                  }}
-                  currentId={category.id}
-                  selectedIds={categoriesIds.map((category) => category.id)}
-                >
-                  {category.category}
-                </CategoryItem>
-              ))}
-          </CategoryListSection>
-        </CategorySelectSection>
-        <DoneButton type="button" onClick={handleSaveCategoryIds}>
-          완료
-        </DoneButton>
-      </CommonModal>
-    </ModalPortal>
+    <CommonModal width="1046px" onClick={onClose}>
+      <ModalCloseButton onClick={onClose} />
+      <CategoryModalTitle>카테고리 선택하기</CategoryModalTitle>
+      <CategorySelectSection>
+        <CategoryListSection>
+          {categories &&
+            categories.map((category) => (
+              <CategoryItem
+                key={category.id}
+                onClick={() => {
+                  onCategoryClick(category.id, category.category);
+                }}
+                currentId={category.id}
+                selectedIds={categoriesIds.map((category) => category.id)}
+              >
+                {category.category}
+              </CategoryItem>
+            ))}
+        </CategoryListSection>
+      </CategorySelectSection>
+      <DoneButton type="button" onClick={handleSaveCategoryIds}>
+        완료
+      </DoneButton>
+    </CommonModal>
   );
 };
 

--- a/src/features/categories/services/categoryApiSlice.ts
+++ b/src/features/categories/services/categoryApiSlice.ts
@@ -1,15 +1,11 @@
 import { apiSlice } from '../../../app/api/apiSlice';
-
-export type categoryType = {
-  id: number;
-  category: string;
-};
+import { CategoryType } from '../../../types/categoryType';
 
 const accessToken = window.localStorage.getItem('admin');
 
 export const eventCategoryApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
-    getEventCategory: builder.query<categoryType[], void>({
+    getEventCategory: builder.query<CategoryType[], void>({
       query: () => 'events/categories',
       providesTags: ['EventCategory'],
     }),

--- a/src/features/events/modals/AddressSearchModal.tsx
+++ b/src/features/events/modals/AddressSearchModal.tsx
@@ -3,9 +3,7 @@ import { useDispatch } from 'react-redux';
 
 import AdressInput, { Place } from '../../../components/AddressInput';
 import KakaoMap from '../../../components/KakaoMap';
-import CommonModal, {
-  ModalPortal,
-} from '../../../components/modal/CommonModal';
+import CommonModal from '../../../components/modal/CommonModal';
 import {
   DoneButton,
   ModalCloseButton,
@@ -42,19 +40,17 @@ const AddressSearchModal = ({ onClose }: ModalProps) => {
   };
 
   return (
-    <ModalPortal>
-      <CommonModal onClick={onHideModal}>
-        <ModalCloseButton type="button" onClick={onHideModal} />
-        <S.Title>주소 검색</S.Title>
-        <S.ContentBox>
-          <AdressInput setCurrentPlace={setCurrentPlace} />
-          <KakaoMap size="address" />
-        </S.ContentBox>
-        <DoneButton type="button" onClick={handleDoneButton}>
-          완료
-        </DoneButton>
-      </CommonModal>
-    </ModalPortal>
+    <CommonModal onClick={onHideModal}>
+      <ModalCloseButton type="button" onClick={onHideModal} />
+      <S.Title>주소 검색</S.Title>
+      <S.ContentBox>
+        <AdressInput setCurrentPlace={setCurrentPlace} />
+        <KakaoMap size="address" />
+      </S.ContentBox>
+      <DoneButton type="button" onClick={handleDoneButton}>
+        완료
+      </DoneButton>
+    </CommonModal>
   );
 };
 

--- a/src/hooks/useImageProcessing.ts
+++ b/src/hooks/useImageProcessing.ts
@@ -2,8 +2,13 @@ import imageCompression from 'browser-image-compression';
 
 import { useAddImageMutation } from '../features/images/imageApiSlice';
 
+interface processImageProps {
+  newImage: File | undefined;
+  savedImage: string | undefined;
+}
+
 const useImageProcessing = (): {
-  uploadImageToServer: (image: File) => Promise<string | undefined>;
+  ImageProcessing: (props: processImageProps) => Promise<string | undefined>;
 } => {
   const [addNewImage] = useAddImageMutation();
 
@@ -37,7 +42,19 @@ const useImageProcessing = (): {
     return filename;
   };
 
-  return { uploadImageToServer: compressAndUploadImage };
+  const ImageProcessing = async ({
+    newImage,
+    savedImage,
+  }: processImageProps) => {
+    if (newImage) {
+      const uploadImage = await compressAndUploadImage(newImage);
+      return uploadImage;
+    } else if (savedImage) {
+      return savedImage;
+    }
+  };
+
+  return { ImageProcessing };
 };
 
 export default useImageProcessing;

--- a/src/pages/ManagePage/Artist/ArtistListItem.tsx
+++ b/src/pages/ManagePage/Artist/ArtistListItem.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from 'react-redux';
 
 import deleteIcon from '../../../assets/delete.svg';
 import editIcon from '../../../assets/edit.svg';
+import defaultImage from '../../../assets/user-profile.svg';
 import { useDeleteArtistsMutation } from '../../../features/artists/services/artistsApiSlice';
 import { editArtistInfo } from '../../../features/artists/services/setArtistSlice';
 import { modals } from '../../../features/modal/ReduxModalRoot';
@@ -19,16 +20,13 @@ import {
   ArtistName,
 } from './ArtistListItemStyle';
 
-const testImg =
-  'https://images.unsplash.com/photo-1567880905822-56f8e06fe630?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=735&q=80';
-
 const ArtistListItem = ({ data }: { data: ArtistContent }) => {
   const baseURL = process.env.REACT_APP_BASE_URL;
   const dispatch = useDispatch();
   const [deleteArtist] = useDeleteArtistsMutation();
   const { openModal } = useModal();
   const artistImage =
-    data.image !== '/images/null' ? baseURL + data.image : testImg;
+    data.image !== '/images/null' ? baseURL + data.image : defaultImage;
 
   const onClickEditBtn = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/pages/MyPage/EditProfile/EditProfile.tsx
+++ b/src/pages/MyPage/EditProfile/EditProfile.tsx
@@ -42,7 +42,7 @@ const EditProfile = () => {
   const [editUserInfo] = useEditUserInfoMutation();
   const [unregister] = useUnregisterMutation();
   const [logout] = useLogoutMutation();
-  const { uploadImageToServer } = useImageProcessing();
+  const { ImageProcessing } = useImageProcessing();
 
   useEffect(() => {
     if (userData) {
@@ -94,7 +94,10 @@ const EditProfile = () => {
 
   const processImage = async () => {
     if (userImage) {
-      const uploadedImage = await uploadImageToServer(userImage);
+      const uploadedImage = await ImageProcessing({
+        newImage: userImage,
+        savedImage: savedImagefile,
+      });
       return uploadedImage;
     } else if (savedImagefile) {
       return savedImagefile;

--- a/src/types/artistsType.ts
+++ b/src/types/artistsType.ts
@@ -1,16 +1,21 @@
-export interface ArtistValue {
+export type ArtistType = {
+  id: number;
+  type: string;
+};
+
+export interface ArtistDataType {
   artistTypeId: number;
   groupId?: number | null;
   name: string;
   image: string;
 }
 
-export type ArtistType = {
-  id: number;
-  type: string;
+export type EditArtistDataType = {
+  artistId: number;
+  artistValue: ArtistDataType;
 };
 
-export interface ArtistsData {
+export interface ArtistsRawDataType {
   totalElements: number;
   totalPages: number;
   sort: {
@@ -52,6 +57,6 @@ export interface ArtistsData {
 }
 
 export type ArtistContent = Pick<
-  ArtistsData['content'][0],
+  ArtistsRawDataType['content'][0],
   'id' | 'groupId' | 'groupName' | 'name' | 'image' | 'artistType'
 >;

--- a/src/types/artisttypeType.ts
+++ b/src/types/artisttypeType.ts
@@ -1,0 +1,6 @@
+export type ArtisttypeType = {
+  id: number;
+  type: string;
+};
+
+export type AritsttypeAddType = Pick<ArtisttypeType, 'type'>;

--- a/src/types/categoryType.ts
+++ b/src/types/categoryType.ts
@@ -1,0 +1,4 @@
+export type CategoryType = {
+  id: number;
+  category: string;
+};

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -10,18 +10,9 @@ import {
 } from '@reduxjs/toolkit/dist/query/baseQueryTypes';
 import { MutationTrigger } from '@reduxjs/toolkit/dist/query/react/buildHooks';
 
-import { ArtistDataType, EditArtistDataType } from '../types/artistsType';
-import { ArtisttypeType, AritsttypeAddType } from '../types/artisttypeType';
-
 import handleErrorResponse from './handleErrorResponse';
 
-type Data =
-  | ArtistDataType
-  | EditArtistDataType
-  | AritsttypeAddType
-  | ArtisttypeType;
-
-export type ApiFunction<T extends Data> = MutationTrigger<
+export type ApiFunction<T> = MutationTrigger<
   MutationDefinition<
     T,
     (
@@ -36,7 +27,7 @@ export type ApiFunction<T extends Data> = MutationTrigger<
   >
 >;
 
-export const performApiAction = async <T extends Data>(
+export const performApiAction = async <T>(
   data: T,
   apiFunction: ApiFunction<T>,
   extraFunction?: () => void,

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -1,0 +1,52 @@
+import {
+  MutationDefinition,
+  FetchBaseQueryError,
+  FetchBaseQueryMeta,
+  FetchArgs,
+} from '@reduxjs/toolkit/dist/query';
+import {
+  QueryReturnValue,
+  BaseQueryApi,
+} from '@reduxjs/toolkit/dist/query/baseQueryTypes';
+import { MutationTrigger } from '@reduxjs/toolkit/dist/query/react/buildHooks';
+
+import { ArtistDataType, EditArtistDataType } from '../types/artistsType';
+
+import handleErrorResponse from './handleErrorResponse';
+
+type Data = ArtistDataType | EditArtistDataType;
+
+export type ApiFunction<T extends Data> = MutationTrigger<
+  MutationDefinition<
+    T,
+    (
+      args: string | FetchArgs,
+      api: BaseQueryApi,
+      extraOptions: object
+    ) => Promise<
+      QueryReturnValue<unknown, FetchBaseQueryError, FetchBaseQueryMeta>
+    >,
+    any,
+    'api'
+  >
+>;
+
+export const performApiAction = async <T extends Data>(
+  data: T,
+  apiFunction: ApiFunction<T>,
+  extraFunction?: () => void,
+  successMessage?: string
+) => {
+  try {
+    const res = await apiFunction(data);
+
+    if ('data' in res) {
+      successMessage && alert(successMessage);
+      extraFunction && extraFunction();
+    } else if ('error' in res) {
+      handleErrorResponse(res.error);
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -11,10 +11,15 @@ import {
 import { MutationTrigger } from '@reduxjs/toolkit/dist/query/react/buildHooks';
 
 import { ArtistDataType, EditArtistDataType } from '../types/artistsType';
+import { ArtisttypeType, AritsttypeAddType } from '../types/artisttypeType';
 
 import handleErrorResponse from './handleErrorResponse';
 
-type Data = ArtistDataType | EditArtistDataType;
+type Data =
+  | ArtistDataType
+  | EditArtistDataType
+  | AritsttypeAddType
+  | ArtisttypeType;
 
 export type ApiFunction<T extends Data> = MutationTrigger<
   MutationDefinition<

--- a/src/utils/handleErrorResponse.ts
+++ b/src/utils/handleErrorResponse.ts
@@ -4,6 +4,7 @@ const handleErrorResponse = (error: any) => {
     if (data !== null && typeof data === 'object' && 'message' in data) {
       const errorMessage = data.message;
       alert(errorMessage);
+      throw new Error('Error');
     }
   } else {
     alert('잠시 후에 다시 시도해주세요.');


### PR DESCRIPTION
## Describe your changes

- ModalPortal을 CommonModal 컴포넌트 내부로 이동
- handleErrorResponse 함수 내부에, 에러 객체 반환 문구 추가
- 로딩창 컴포넌트 렌더링 로직 수정 (setIsRequesting을 finally 로 이동)
- 로딩창 컴포넌트에 default text 추가
- performApiAction 함수 생성 (api 요청 함수 전달 시 이를 실행시키고 에러처리 하는 함수)
- useImageProcessing 훅 내부에 ImageProcessing 함수 생성 (이미지 압축 및 저장 로직은 겉으로 드러날 필요가 없을 거 같아서 새로운 함수를 만들었습니다)
- typeButton props 수정


## To-do before merge

작업하다보니 pr 크기가 좀 커졌네요 🥺 감사합니당 🌞
